### PR TITLE
Feature/auction amount summary

### DIFF
--- a/src/actions/tokenPair.ts
+++ b/src/actions/tokenPair.ts
@@ -2,3 +2,4 @@ import { createAction } from 'redux-actions'
 import { TokenPair } from 'types'
 
 export const selectTokenPair = createAction<TokenPair>('SELECT_TOKEN_PAIR')
+export const setSellTokenAmount = createAction<{ sellAmount: number }>('SET_SELL_TOKEN_AMOUNT')

--- a/src/components/AuctionAmountSummary/index.tsx
+++ b/src/components/AuctionAmountSummary/index.tsx
@@ -1,14 +1,14 @@
 import React from 'react'
 import { TokenCode, Balance } from 'types'
 
-export interface TokenPairProps {
+export interface AuctionAmountSummaryProps {
   sellToken: TokenCode,
   buyToken: TokenCode,
   sellTokenAmount: Balance,
   buyTokenAmount: Balance,
 }
 
-const TokenPair: React.SFC<TokenPairProps> = ({
+const AuctionAmountSummary: React.SFC<AuctionAmountSummaryProps> = ({
   sellToken, buyToken, sellTokenAmount, buyTokenAmount,
 }) => (
     <div className="auctionAmountSummary">
@@ -26,4 +26,4 @@ const TokenPair: React.SFC<TokenPairProps> = ({
     </div>
   )
 
-export default TokenPair
+export default AuctionAmountSummary

--- a/src/components/AuctionAmountSummary/index.tsx
+++ b/src/components/AuctionAmountSummary/index.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import { TokenCode, Balance } from 'types'
+
+export interface TokenPairProps {
+  sellToken: TokenCode,
+  buyToken: TokenCode,
+  sellTokenAmount: Balance,
+  buyTokenAmount: Balance,
+}
+
+const TokenPair: React.SFC<TokenPairProps> = ({
+  sellToken, buyToken, sellTokenAmount, buyTokenAmount,
+}) => (
+    <div className="auctionAmountSummary">
+      <span className="tokenItemSummary">
+        <i data-coin={sellToken}></i>
+        <big>SELLING</big>
+        <p>{sellTokenAmount} {sellToken}</p>
+      </span>
+
+      <span className="tokenItemSummary">
+        <i data-coin={buyToken}></i>
+        <big>BUYING</big>
+        <p>{buyTokenAmount} {buyToken}</p>
+      </span>
+    </div>
+  )
+
+export default TokenPair

--- a/src/components/AuctionSellingGetting/index.tsx
+++ b/src/components/AuctionSellingGetting/index.tsx
@@ -4,41 +4,30 @@ import { Balance, TokenCode } from 'types'
 
 /* CONSIDER ADDING GAS_COST */
 export interface AuctionSellingGettingProps {
-  balance: Balance,
+  sellTokenBalance: Balance,
   buyToken: TokenCode,
-  ratio: number,
   sellToken: TokenCode,
+  sellAmount: Balance,
+  buyAmount: Balance,
+  setSellTokenAmount(props: any): any,
 }
 
-export interface AuctionSellingGettingState {
-  value: string | number
-}
 
-class AuctionSellingGetting extends Component<AuctionSellingGettingProps, AuctionSellingGettingState> {
-
-  state = {
-    value: 0,
-  }
-
+class AuctionSellingGetting extends Component<AuctionSellingGettingProps> {
   onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    this.setState({
-      value: e.target.value,
-    })
+    this.props.setSellTokenAmount({ sellAmount: e.target.value })
   }
 
   onClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
-    const { balance } = this.props
+    const { sellTokenBalance, setSellTokenAmount } = this.props
 
     e.preventDefault()
 
-    this.setState({
-      value: Number(balance),
-    })
+    setSellTokenAmount({ sellAmount: sellTokenBalance })
   }
 
   render() {
-    const { sellToken, buyToken, ratio, balance } = this.props
-    const { value } = this.state
+    const { sellToken, buyToken, buyAmount, sellTokenBalance, sellAmount } = this.props
 
     return (
       <div className="auctionAmounts">
@@ -49,15 +38,16 @@ class AuctionSellingGetting extends Component<AuctionSellingGettingProps, Auctio
           name="sellingAmount"
           id="sellingAmount"
           onChange={this.onChange}
-          value={value}
+          value={sellAmount}
           min="0"
-          max={balance}
+          max={sellTokenBalance}
         />
         <small>{sellToken}</small>
 
         <label htmlFor="gettingAmount">Est. Amount Getting:</label>
         {/* CONSIDER ADDING GAS_COST TO RATIO */}
-        <input type="number" name="gettingAmount" id="gettingAmount" value={value * ratio} readOnly />
+        {/* TODO: use BN.mult() */}
+        <input type="number" name="gettingAmount" id="gettingAmount" value={buyAmount} readOnly />
         <small>{buyToken}</small>
       </div>
     )

--- a/src/components/ButtonCTA/index.tsx
+++ b/src/components/ButtonCTA/index.tsx
@@ -5,7 +5,7 @@ import { Link } from 'react-router-dom'
 interface ButtonCTAProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
   className?: string,
   onClick?(e: React.MouseEvent<HTMLAnchorElement>): void,
-  to: string,
+  to?: string,
 }
 
 class ButtonCTA extends PureComponent<ButtonCTAProps> {
@@ -21,13 +21,14 @@ class ButtonCTA extends PureComponent<ButtonCTAProps> {
   }
 
   render() {
-    const { className, children, onClick, ...rest } = this.props
+    const { className, children, onClick, to = '', ...rest } = this.props
 
     return (
       <Link
         href="#"
         className={'buttonCTA ' + (className || '')}
         onClick={this.onClick}
+        to={to}
         {...rest}
       >
         {children}

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -3,11 +3,12 @@ import * as React from 'react'
 import MenuWallet from 'containers/MenuWallet'
 import MenuAuctions from 'containers/MenuAuctions'
 import Hamburger from 'components/Hamburger'
+import { Link } from 'react-router-dom'
 
 export const Header: React.SFC = () => (
   <header>
     <div>
-      <a href="#" title="DutchX - Dutch Auction Exchange" className="logo"></a>
+      <Link to="/" title="DutchX - Dutch Auction Exchange" className="logo"></Link>
       <MenuWallet />
       <MenuAuctions />
       <Hamburger />

--- a/src/components/OrderPanel/index.tsx
+++ b/src/components/OrderPanel/index.tsx
@@ -19,7 +19,7 @@ const OrderPanel: React.SFC<OrderPanelProps> = ({ sellToken, buyToken }) => (
   <AuctionContainer auctionDataScreen="amount">
     <TokenOverlay />
     <AuctionHeader backTo="/">
-      Token Auction ${sellToken}/${buyToken}
+      Token Auction {sellToken}/{buyToken}
     </AuctionHeader>
     <TokenPair />
     <AuctionPriceBar header="Closing Price" />

--- a/src/components/OrderPanel/index.tsx
+++ b/src/components/OrderPanel/index.tsx
@@ -6,6 +6,7 @@ import AuctionPriceBar from 'containers/AuctionPriceBar'
 import AuctionSellingGetting from 'containers/AuctionSellingGetting'
 import ButtonCTA from 'components/ButtonCTA'
 import TokenPair from 'containers/TokenPair'
+import TokenOverlay from 'containers/TokenOverlay'
 
 import { TokenCode } from 'types'
 
@@ -16,6 +17,7 @@ interface OrderPanelProps {
 
 const OrderPanel: React.SFC<OrderPanelProps> = ({ sellToken, buyToken }) => (
   <AuctionContainer auctionDataScreen="amount">
+    <TokenOverlay />
     <AuctionHeader backTo="/">
       Token Auction ${sellToken}/${buyToken}
     </AuctionHeader>

--- a/src/components/TokenPair/index.tsx
+++ b/src/components/TokenPair/index.tsx
@@ -1,22 +1,38 @@
 import React from 'react'
 import TokenItem from '../TokenItem'
 import { code2tokenMap } from 'globals'
-import { TokenPair, TokenBalances } from 'types'
+import { TokenCode, Balance } from 'types'
 
 export interface TokenPairProps {
-  tokenBalances: TokenBalances,
-  tokenPair: TokenPair,
+  sellToken: TokenCode,
+  buyToken: TokenCode,
+  sellTokenBalance: Balance,
+  buyTokenBalance: Balance,
   openOverlay(): any
 }
 
 const TokenPair: React.SFC<TokenPairProps> = ({
-  tokenPair: { sell, buy },
-  tokenBalances: { [sell]: sellTokenBalance, [buy]: buyTokenBalance },
+  sellToken,
+  buyToken,
+  sellTokenBalance,
+  buyTokenBalance,
   openOverlay,
 }) => (
     <div className="tokenPair">
-      <TokenItem code={sell} name={code2tokenMap[sell]} balance={sellTokenBalance} mod="sell" onClick={openOverlay} />
-      <TokenItem code={buy} name={code2tokenMap[buy]} balance={buyTokenBalance} mod="buy" onClick={openOverlay} />
+      <TokenItem
+        code={sellToken}
+        name={code2tokenMap[sellToken]}
+        balance={sellTokenBalance}
+        mod="sell"
+        onClick={openOverlay}
+      />
+      <TokenItem
+        code={buyToken}
+        name={code2tokenMap[buyToken]}
+        balance={buyTokenBalance}
+        mod="buy"
+        onClick={openOverlay}
+      />
     </div>
   )
 

--- a/src/components/TopAuctions/index.tsx
+++ b/src/components/TopAuctions/index.tsx
@@ -3,7 +3,7 @@ import { RatioPairs, TokenPair } from 'types'
 
 export interface TopAuctionsProps {
   pairs: RatioPairs,
-  selectTokenPair(pair: TokenPair): any
+  selectTokenPair(pair: Pick<TokenPair, 'sell' | 'buy'>): any
 }
 
 const TopAuctions: React.SFC<TopAuctionsProps> = ({ pairs, selectTokenPair }) => (

--- a/src/components/WalletPanel/index.tsx
+++ b/src/components/WalletPanel/index.tsx
@@ -5,7 +5,7 @@ import AuctionHeader from 'components/AuctionHeader'
 import AuctionPriceBar from 'containers/AuctionPriceBar'
 import AuctionWalletSummary from 'containers/AuctionWalletSummary'
 import ButtonCTA from 'components/ButtonCTA'
-import TokenPair from 'containers/TokenPair'
+import AuctionAmountSummary from 'containers/AuctionAmountSummary'
 
 interface WalletPanelProps {
   auctionAddress: string
@@ -17,7 +17,7 @@ const WalletPanel: React.SFC<WalletPanelProps> = ({ auctionAddress }) => (
     <AuctionHeader backTo="/order">
       Confirm Order Details
       </AuctionHeader>
-    <TokenPair />
+    <AuctionAmountSummary />
     <AuctionPriceBar header="Price" />
     <AuctionWalletSummary />
     <p>

--- a/src/containers/AuctionAmountSummary/index.ts
+++ b/src/containers/AuctionAmountSummary/index.ts
@@ -1,0 +1,29 @@
+import { connect } from 'react-redux'
+import { createSelector } from 'reselect'
+
+import { State, RatioPairs, TokenCode } from 'types'
+import AuctionAmountSummary from 'components/AuctionAmountSummary'
+
+// TODO: move to selectors
+const findRatioPair = createSelector(
+  ({ tokenPair }) => tokenPair.sell,
+  ({ tokenPair }) => tokenPair.buy,
+  ({ ratioPairs }) => ratioPairs,
+  (sell: TokenCode, buy: TokenCode, ratioPairs: RatioPairs) => ratioPairs.find(
+    pair => pair.sell === sell && pair.buy === buy),
+)
+
+const mapState = (state: State) => {
+  // TODO: always have some price for every pair in RatioPairs
+  const { sell, buy, price, sellAmount } = findRatioPair(state) || Object.assign({ price: 2 }, state.tokenPair)
+  return ({
+    // TODO: change prop to sellTokenBalance
+    sellToken: sell,
+    buyToken: buy,
+    sellTokenAmount: sellAmount,
+    // TODO: use BN.mult() inside component
+    buyTokenAmount: (+price * +sellAmount).toString(),
+  })
+}
+
+export default connect(mapState)(AuctionAmountSummary)

--- a/src/containers/AuctionAmountSummary/index.ts
+++ b/src/containers/AuctionAmountSummary/index.ts
@@ -15,7 +15,8 @@ const findRatioPair = createSelector(
 
 const mapState = (state: State) => {
   // TODO: always have some price for every pair in RatioPairs
-  const { sell, buy, price, sellAmount } = findRatioPair(state) || Object.assign({ price: 2 }, state.tokenPair)
+  const { sell, buy, price } = findRatioPair(state) || Object.assign({ price: 2 }, state.tokenPair)
+  const { sellAmount } = state.tokenPair
   return ({
     // TODO: change prop to sellTokenBalance
     sellToken: sell,

--- a/src/containers/AuctionSellingGetting/index.ts
+++ b/src/containers/AuctionSellingGetting/index.ts
@@ -1,8 +1,9 @@
 import { connect } from 'react-redux'
 import { createSelector } from 'reselect'
+import { setSellTokenAmount } from 'actions'
 
 import { State, RatioPairs, TokenCode } from 'types'
-import AuctionSellingGetting from 'components/AuctionSellingGetting'
+import AuctionSellingGetting, { AuctionSellingGettingProps } from 'components/AuctionSellingGetting'
 
 // TODO: move to selectors
 const findRatioPair = createSelector(
@@ -16,15 +17,18 @@ const findRatioPair = createSelector(
 const mapState = (state: State) => {
   // TODO: always have some price for every pair in RatioPairs
   const { sell, buy, price } = findRatioPair(state) || Object.assign({ price: 2 }, state.tokenPair)
-  const { [sell]: balance } = state.tokenBalances
+  const { [sell]: sellTokenBalance } = state.tokenBalances
+  const { sellAmount } = state.tokenPair
+
   return ({
     // TODO: change prop to sellTokenBalance
-    balance,
+    sellTokenBalance,
     sellToken: sell,
     buyToken: buy,
-    // TODO: use BN.mult() inside component
-    ratio: +price,
-  })
+    sellAmount,
+    // TODO: use BN.mult()
+    buyAmount: (+sellAmount * +price).toString(),
+  }) as AuctionSellingGettingProps
 }
 
-export default connect(mapState)(AuctionSellingGetting)
+export default connect(mapState, { setSellTokenAmount })(AuctionSellingGetting)

--- a/src/containers/TokenPair/index.ts
+++ b/src/containers/TokenPair/index.ts
@@ -3,10 +3,15 @@ import TokenPair from 'components/TokenPair'
 import { openOverlay } from 'actions'
 import { State } from 'types'
 
-const mapStateToProps = ({ tokenPair, tokenBalances }: State) => ({
-  tokenPair,
-  tokenBalances,
-})
+const mapStateToProps = ({
+  tokenPair: { sell, buy },
+  tokenBalances: { [sell]: sellTokenBalance = 0, [buy]: buyTokenBalance = 0 },
+  }: State) => ({
+    sellToken: sell,
+    buyToken: buy,
+    sellTokenBalance,
+    buyTokenBalance,
+  })
 
 
 export default connect(mapStateToProps, { openOverlay })(TokenPair)

--- a/src/reducers/tokenOverlay.ts
+++ b/src/reducers/tokenOverlay.ts
@@ -8,7 +8,7 @@ export default handleActions<TokenOverlay>(
     [closeOverlay.toString()]: state => ({
       ...state,
       open: false,
-      mode: null,
+      mod: null,
     }),
     [openOverlay.toString()]: (state, action) => ({
       ...state,

--- a/src/reducers/tokenPair.ts
+++ b/src/reducers/tokenPair.ts
@@ -1,6 +1,6 @@
 import { handleActions } from 'redux-actions'
 
-import { selectTokenAndCloseOverlay, selectTokenPair } from 'actions'
+import { selectTokenAndCloseOverlay, selectTokenPair, setSellTokenAmount } from 'actions'
 import { TokenPair } from 'types'
 import { TokenItemProps } from 'components/TokenItem'
 
@@ -11,12 +11,21 @@ export default handleActions<TokenPair, TokenItemProps & TokenPair>(
       return {
         ...state,
         [mod]: code,
+        sellAmount: '0',
       }
     },
-    [selectTokenPair.toString()]: (_, action) => action.payload,
+    [selectTokenPair.toString()]: (_, action) => ({
+      ...action.payload,
+      sellAmount: '0',
+    }),
+    [setSellTokenAmount.toString()]: (state, action) => ({
+      ...state,
+      ...action.payload,
+    }),
   },
   {
     sell: 'ETH',
     buy: 'GNO',
+    sellAmount: '0',
   },
 )

--- a/src/reducers/tokenPair.ts
+++ b/src/reducers/tokenPair.ts
@@ -20,6 +20,7 @@ export default handleActions<TokenPair, TokenItemProps & TokenPair>(
     }),
     [setSellTokenAmount.toString()]: (state, action) => ({
       ...state,
+      // TODO: restrict payload.sellAmount to [0, tokenBalances[state.sell]]
       ...action.payload,
     }),
   },

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -14,6 +14,8 @@ interface AppRouterProps {
   history: History
 }
 
+// TODO: consider redirecting from inside /order, /wallet, /auction/:nonexistent_addr to root
+
 const AppRouter: React.SFC<AppRouterProps> = ({ history }) => (
   <ConnectedRouter history={history}>
     <div>

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -54,15 +54,18 @@ export type TokenBalances = {[code in TokenCode]?: Balance }
  */
 export interface TokenPair {
   sell: TokenCode,
-  buy: TokenCode
+  buy: TokenCode,
+  sellAmount: Balance,
 }
 
 /**
  * represents a buy/sell pair
  * used in TopAuctions
  */
-export interface RatioPair extends TokenPair {
-  price: Balance
+export interface RatioPair {
+  sell: TokenCode,
+  buy: TokenCode,
+  price: Balance,
 }
 
 export type RatioPairs = RatioPair[]

--- a/stories/AuctionAmountSummary.tsx
+++ b/stories/AuctionAmountSummary.tsx
@@ -12,6 +12,7 @@ import { makeCenterDecorator } from './helpers'
 const CenterDecor = makeCenterDecorator({
   style: {
     height: null,
+    padding: '60px 0',
   },
 })
 

--- a/stories/AuctionAmountSummary.tsx
+++ b/stories/AuctionAmountSummary.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react'
+
+import { storiesOf } from '@storybook/react'
+import { text, number } from '@storybook/addon-knobs'
+import { TokenCode } from 'types'
+
+import AuctionAmountSummary from 'components/AuctionAmountSummary'
+
+import { makeCenterDecorator } from './helpers'
+
+
+const CenterDecor = makeCenterDecorator({
+  style: {
+    height: null,
+  },
+})
+
+storiesOf('AuctionAmountSummary', module)
+  .addDecorator(CenterDecor)
+  .addWithJSX('PANEL 3', () => (
+    <AuctionAmountSummary
+      buyToken={text('buyToken', 'GNO') as TokenCode}
+      sellToken={text('sellToken', 'ETH') as TokenCode}
+      sellTokenAmount={number('sellAmount', 1.00000000).toString()}
+      buyTokenAmount={number('buyAmount', 0.459459434).toString()}
+    />
+  ))

--- a/stories/AuctionContainer.tsx
+++ b/stories/AuctionContainer.tsx
@@ -14,6 +14,7 @@ import AuctionWalletSummary from 'components/AuctionWalletSummary'
 import ButtonCTA from 'components/ButtonCTA'
 import TokenPair from 'containers/TokenPair'
 import AuctionAmountSummary from 'containers/AuctionAmountSummary'
+import TokenOverlay from 'containers/TokenOverlay'
 
 import { action } from '@storybook/addon-actions'
 import { boolean, number, text } from '@storybook/addon-knobs'
@@ -28,6 +29,7 @@ storiesOf('AuctionContainer', module)
   .addDecorator(Provider)
   .addWithJSX('PAGE 2', () =>
     <AuctionContainer auctionDataScreen="amount">
+      <TokenOverlay />
       <AuctionHeader
         backTo="/"
         children="Token Auction ETH/GNO"

--- a/stories/AuctionContainer.tsx
+++ b/stories/AuctionContainer.tsx
@@ -46,7 +46,7 @@ storiesOf('AuctionContainer', module)
         buyToken={text('buyToken', 'GNO') as TokenCode}
         sellToken={text('sellToken', 'ETH') as TokenCode}
         sellAmount={number('sellAmount', 0).toString()}
-        buyAmount={number('sellAmount', 0).toString()}
+        buyAmount={number('buyAmount', 0).toString()}
         setSellTokenAmount={action('Set sellTokenAmount')}
       />
       <ButtonCTA

--- a/stories/AuctionContainer.tsx
+++ b/stories/AuctionContainer.tsx
@@ -13,6 +13,7 @@ import AuctionStatus from 'components/AuctionStatus'
 import AuctionWalletSummary from 'components/AuctionWalletSummary'
 import ButtonCTA from 'components/ButtonCTA'
 import TokenPair from 'containers/TokenPair'
+import AuctionAmountSummary from 'containers/AuctionAmountSummary'
 
 import { action } from '@storybook/addon-actions'
 import { boolean, number, text } from '@storybook/addon-knobs'
@@ -58,7 +59,7 @@ storiesOf('AuctionContainer', module)
         backTo="/"
         children="Confirm Order Details"
       />
-      <TokenPair />
+      <AuctionAmountSummary />
       <AuctionPriceBar header="Price" />
       <AuctionWalletSummary
         address={text('Wallet Addr.', '0x67a8s8ff687asd6a8s9d8fa')}

--- a/stories/AuctionContainer.tsx
+++ b/stories/AuctionContainer.tsx
@@ -50,7 +50,6 @@ storiesOf('AuctionContainer', module)
         })}
       />
       <ButtonCTA
-        to=""
         children="Continue to wallet details"
         onClick={action('Continuing to Wallet Details')}
       />
@@ -74,7 +73,7 @@ storiesOf('AuctionContainer', module)
         When submitting the order and signing with MetaMask,
         your deposit will be added to the next (scheduled) auction. Every auction takes approx. 5 hours.
       </p>
-      <ButtonCTA onClick={action('Order Submitted')} to="">
+      <ButtonCTA onClick={action('Order Submitted')}>
         Submit Order <i className="icon icon-walletOK"></i>
       </ButtonCTA>
     </AuctionContainer>,

--- a/stories/AuctionContainer.tsx
+++ b/stories/AuctionContainer.tsx
@@ -34,7 +34,7 @@ storiesOf('AuctionContainer', module)
       <TokenPair />
       <AuctionPriceBar header="Closing Price" />
       <AuctionSellingGetting
-        balance={number('balance', 0, {
+        sellTokenBalance={number('balance', 0, {
           range: true,
           min: 0,
           max: 5000,
@@ -42,12 +42,9 @@ storiesOf('AuctionContainer', module)
         }).toString()}
         buyToken={text('buyToken', 'GNO') as TokenCode}
         sellToken={text('sellToken', 'ETH') as TokenCode}
-        ratio={number('multiplier', 1, {
-          range: true,
-          min: 0.01,
-          max: 20,
-          step: 0.1,
-        })}
+        sellAmount={number('sellAmount', 0).toString()}
+        buyAmount={number('sellAmount', 0).toString()}
+        setSellTokenAmount={action('Set sellTokenAmount')}
       />
       <ButtonCTA
         children="Continue to wallet details"

--- a/stories/AuctionSellingGetting.tsx
+++ b/stories/AuctionSellingGetting.tsx
@@ -22,12 +22,19 @@ import AuctionSellingGetting from 'components/AuctionSellingGetting'
 storiesOf('Auction Sell & Get', module)
   .addDecorator(CenterDecorator)
   // .addDecorator(ProviderDecor)
-  .add('AuctionSellingGetting', () =>
-    <AuctionSellingGetting
-      sellTokenBalance={text('balance', '20')}
-      buyToken={text('buyToken', 'GNO') as TokenCode}
-      sellToken={text('sellToken', 'ETH') as TokenCode}
-      sellAmount={number('sellAmount', 0).toString()}
-      buyAmount={number('sellAmount', 0).toString()}
-      setSellTokenAmount={action('Set sellTokenAmount')}
-    />)
+  .add('AuctionSellingGetting', () => {
+    const sellAmount = number('sellAmount', 0).toString()
+    const ratio = number('sellRatio', 1.5)
+    const buyAmount = (+sellAmount * ratio).toString()
+
+    return (
+      <AuctionSellingGetting
+        sellTokenBalance={text('balance', '20')}
+        buyToken={text('buyToken', 'GNO') as TokenCode}
+        sellToken={text('sellToken', 'ETH') as TokenCode}
+        sellAmount={sellAmount}
+        buyAmount={buyAmount}
+        setSellTokenAmount={action('Set sellTokenAmount')}
+      />
+    )
+  })

--- a/stories/AuctionSellingGetting.tsx
+++ b/stories/AuctionSellingGetting.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 import { storiesOf } from '@storybook/react'
 import { number, text } from '@storybook/addon-knobs'
+import { action } from '@storybook/addon-actions'
 import { makeCenterDecorator/*, storeInit, bcMetamask, makeProviderDecorator */ } from './helpers'
 
 import { TokenCode } from 'types'
@@ -21,10 +22,12 @@ import AuctionSellingGetting from 'components/AuctionSellingGetting'
 storiesOf('Auction Sell & Get', module)
   .addDecorator(CenterDecorator)
   // .addDecorator(ProviderDecor)
-  .add('AuctionSellingGetting', () => 
+  .add('AuctionSellingGetting', () =>
     <AuctionSellingGetting
-      balance={text('balance', '20')} 
+      sellTokenBalance={text('balance', '20')}
       buyToken={text('buyToken', 'GNO') as TokenCode}
-      ratio={number('sellRatio', 1.0)}
       sellToken={text('sellToken', 'ETH') as TokenCode}
+      sellAmount={number('sellAmount', 0).toString()}
+      buyAmount={number('sellAmount', 0).toString()}
+      setSellTokenAmount={action('Set sellTokenAmount')}
     />)

--- a/stories/ButtonCTA.tsx
+++ b/stories/ButtonCTA.tsx
@@ -3,6 +3,7 @@ import * as React from 'react'
 import { storiesOf } from '@storybook/react'
 import { text } from '@storybook/addon-knobs'
 import { action } from '@storybook/addon-actions'
+import StoryRouter from 'storybook-router'
 
 import { makeCenterDecorator } from './helpers'
 import ButtonCTA from 'components/ButtonCTA'
@@ -21,6 +22,7 @@ const variants = {
 }
 
 const story = storiesOf(`ButtonCTA`, module)
+  .addDecorator(StoryRouter())
   .addDecorator(CenterDecor)
 
 for (const vr of Object.keys(variants)) {

--- a/stories/ButtonCTA.tsx
+++ b/stories/ButtonCTA.tsx
@@ -27,7 +27,6 @@ for (const vr of Object.keys(variants)) {
   story.addWithJSX(vr, () => (
     <ButtonCTA
       onClick={action('ButtonCTA clicked')}
-      to=""
     >
       {variants[vr]}
     </ButtonCTA>

--- a/stories/Header.tsx
+++ b/stories/Header.tsx
@@ -1,14 +1,16 @@
 import * as React from 'react'
 
-const { storiesOf } = require('@storybook/react')
-import { storeInit, bcMetamask } from './helpers'
+import { storiesOf } from '@storybook/react'
+import StoryRouter from 'storybook-router'
+import { storeInit, bcMetamask, makeProviderDecorator } from './helpers'
 
 const store = storeInit(bcMetamask)
 
-import { Provider } from 'react-redux'
+const ProviderDecor = makeProviderDecorator(store)
 
 import Header from 'components/Header'
 
 storiesOf('Header [v2]', module)
-  .addDecorator((story: any) => <Provider store={store as any}>{story()}</Provider>)
+  .addDecorator(StoryRouter())
+  .addDecorator(ProviderDecor)
   .add('Header', () => <Header />)

--- a/stories/Home.tsx
+++ b/stories/Home.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { storiesOf } from '@storybook/react'
+import StoryRouter from 'storybook-router'
 import { storeInit, bcMetamask, makeProviderDecorator } from './helpers'
 
 const store = storeInit(bcMetamask)
@@ -10,5 +11,6 @@ const ProviderDecor = makeProviderDecorator(store)
 import Home from 'containers/Home'
 
 storiesOf('Home', module)
+  .addDecorator(StoryRouter())
   .addDecorator(ProviderDecor)
   .add('Home', () => <Home />)

--- a/stories/NoWallet.tsx
+++ b/stories/NoWallet.tsx
@@ -3,6 +3,7 @@ import * as React from 'react'
 import { storiesOf } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 import { boolean } from '@storybook/addon-knobs'
+import StoryRouter from 'storybook-router'
 
 import { storeInit, bcMetamask, makeProviderDecorator, CenterSectionDecorator } from './helpers'
 
@@ -12,8 +13,9 @@ import TextSquare from 'components/TextSquare'
 import NoWallet from 'components/NoWallet'
 
 storiesOf('NoWallet', module)
-  .addDecorator(CenterSectionDecorator)
+  .addDecorator(StoryRouter())
   .addDecorator(makeProviderDecorator(store))
+  .addDecorator(CenterSectionDecorator)
   .addWithJSX('NoWallet[Solo]', () =>
     <NoWallet
       handleClick={action('ButtonCTA clicked')}

--- a/stories/TextSquare.tsx
+++ b/stories/TextSquare.tsx
@@ -24,8 +24,9 @@ storiesOf('TextSquare', module)
 )
   .addWithJSX('TextSquareBoth', (): any =>
     [
-      <TextSquare />,
+      <TextSquare key="0" />,
       <NoWallet
+        key="1"
         handleClick={action('ButtonCTA clicked')}
         hide={boolean('Hide/Show', false)}
       />,

--- a/stories/TextSquare.tsx
+++ b/stories/TextSquare.tsx
@@ -3,6 +3,7 @@ import * as React from 'react'
 import { storiesOf } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 import { boolean } from '@storybook/addon-knobs'
+import StoryRouter from 'storybook-router'
 
 import TextSquare from 'components/TextSquare'
 import NoWallet from 'components/NoWallet'
@@ -10,6 +11,7 @@ import NoWallet from 'components/NoWallet'
 import { CenterSectionDecorator } from './helpers'
 
 storiesOf('TextSquare', module)
+  .addDecorator(StoryRouter())
   .addDecorator(CenterSectionDecorator)
   .addWithJSX('TextSquareLeft[Intro]', () =>
     <TextSquare />,

--- a/stories/TokenPair.tsx
+++ b/stories/TokenPair.tsx
@@ -24,11 +24,20 @@ const getModFromArgs = decorateAction([
   args => [args[0].mod],
 ])
 
-const tokenPair = () => <TokenPair
-  openOverlay={getModFromArgs('OPEN OVERLAY to select a token to')}
-  tokenPair={object('tokenPair', codePair)}
-  tokenBalances={object('tokenBalances', tokenBalances)}
-/>
+const tokenPair = () => {
+  const { sell, buy } = object('tokenPair', codePair)
+  const { [sell]: sellTokenBalance, [buy]: buyTokenBalance } = object('tokenBalances', tokenBalances)
+
+  return (
+    <TokenPair
+      openOverlay={getModFromArgs('OPEN OVERLAY to select a token to')}
+      sellToken={sell}
+      buyToken={buy}
+      sellTokenBalance={sellTokenBalance}
+      buyTokenBalance={buyTokenBalance}
+    />
+  )
+}
 
 storiesOf('TokenPair', module)
   .addDecorator(CenterDecor)

--- a/stories/TokenPair.tsx
+++ b/stories/TokenPair.tsx
@@ -14,8 +14,9 @@ const tokenBalances = generateTokenBalances()
 
 const CenterDecor = makeCenterDecorator({
   style: {
-    width: 500,
+    width: 650,
     height: null,
+    backgroundColor: null,
   },
 })
 
@@ -23,10 +24,21 @@ const getModFromArgs = decorateAction([
   args => [args[0].mod],
 ])
 
+const tokenPair = () => <TokenPair
+  openOverlay={getModFromArgs('OPEN OVERLAY to select a token to')}
+  tokenPair={object('tokenPair', codePair)}
+  tokenBalances={object('tokenBalances', tokenBalances)}
+/>
+
 storiesOf('TokenPair', module)
   .addDecorator(CenterDecor)
-  .addWithJSX('SELL <-> RECEIVE', () => <TokenPair
-    openOverlay={getModFromArgs('OPEN OVERLAY to select a token to')}
-    tokenPair={object('tokenPair', codePair)}
-    tokenBalances={object('tokenBalances', tokenBalances)}
-  />)
+  .addWithJSX('HOME', () => (
+    <div className="tokenIntro" style={{ width: 540, backgroundColor: 'white', margin: 'auto' }}>
+      {tokenPair()}
+    </div>
+  ))
+  .addWithJSX('PANEL 2', () => (
+    <div className="auctionContainer">
+      {tokenPair()}
+    </div>
+  ))

--- a/stories/TokenPicker.tsx
+++ b/stories/TokenPicker.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 
 import { storiesOf } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
+import StoryRouter from 'storybook-router'
 
 import TokenPicker from 'components/TokenPicker'
 
@@ -35,6 +36,7 @@ const CenterDecor = makeCenterDecorator({
 })
 
 storiesOf('TokenPicker', module)
+  .addDecorator(StoryRouter())
   .addDecorator(makeProviderDecorator(store))
   .addDecorator(CenterDecor)
   .addWithJSX('main', () => <TokenPicker

--- a/stories/TokenPicker.tsx
+++ b/stories/TokenPicker.tsx
@@ -22,6 +22,7 @@ const store = storeInit({
   tokenPair: {
     sell: 'ETH',
     buy: 'GNO',
+    sellAmount: '0',
   },
   ratioPairs,
 })

--- a/stories/helpers/fn.ts
+++ b/stories/helpers/fn.ts
@@ -89,5 +89,5 @@ const samplePair = (list: any[]): [any, any] => {
  */
 export const generateTokenPair = (codes = codeList): TokenPair => {
   const [sell, buy] = samplePair(codes)
-  return { sell, buy }
+  return { sell, buy, sellAmount: '0' }
 }

--- a/stories/helpers/mockStore.ts
+++ b/stories/helpers/mockStore.ts
@@ -28,9 +28,9 @@ export const bcMetamask: Partial<State> = {
     dutchXInitialized: true,
     ongoingAuctions: [],
   },
-  tokenBalances: { 
+  tokenBalances: {
     GNO: '0.12364',
-    ETH: '0.46783', 
+    ETH: '0.46783',
   },
 }
 
@@ -46,8 +46,8 @@ export const bcLocalHost: Partial<State> = {
     dutchXInitialized: true,
     ongoingAuctions: [],
   },
-  tokenBalances:{ 
-    GNO: '0.12364', 
+  tokenBalances: {
+    GNO: '0.12364',
   },
 }
 
@@ -55,5 +55,6 @@ export const tokenPairState: Partial<State> = {
   tokenPair: {
     sell: 'ETH',
     buy: '1ST',
+    sellAmount: '0',
   },
 }


### PR DESCRIPTION
Changes:

1. Added `AuctionAmountSummary` component that looks like a static `TokenPair` with already set selling and buying amounts.
2. `TokenPair` state now includes `sellAmount` field, which together with closing price makes up estimated `buyAmount`
2. Made `AuctionSellingGetting` into a controlled component, so that we can pull `sellAmount` whenever we need it, e.g. in `AuctionAmountSummary`, and later when submitting sell order.
3. Added `TokenOverlay` to `PANEL 2`
4. misc fixes