### PR TITLE
Feature/truffle scripts2

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -55,6 +55,14 @@
     "one-var-declaration-per-line": 0,
     "no-nested-ternary": 0,
     "no-await-in-loop": 0,
+    "import/no-extraneous-dependencies": [
+      "error",
+      {
+        "devDependencies": true,
+        "optionalDependencies": false,
+        "peerDependencies": false
+      }
+    ],
     "semi": [
       "error",
       "never"

--- a/.eslintrc
+++ b/.eslintrc
@@ -55,6 +55,7 @@
     "one-var-declaration-per-line": 0,
     "no-nested-ternary": 0,
     "no-await-in-loop": 0,
+    "no-multi-assign": 0,
     "import/no-extraneous-dependencies": [
       "error",
       {

--- a/package.json
+++ b/package.json
@@ -173,6 +173,7 @@
     "less": "^2.7.2",
     "less-loader": "^4.0.5",
     "lint-staged": "^4.2.3",
+    "minimist": "^1.2.0",
     "mocha": "^4.0.1",
     "name-all-modules-plugin": "^1.0.1",
     "node-sass": "^4.5.3",

--- a/trufflescripts/buy_order.js
+++ b/trufflescripts/buy_order.js
@@ -69,7 +69,7 @@ module.exports = async () => {
     }
 
     await gno.approve(dx.address, amount, { from: buyer })
-    await dx.postBuyOrder(amount, 1, { from: buyer })
+    await dx.postBuyOrder(amount, auctionIndex, { from: buyer })
   } catch (error) {
     console.error(error.message || error)
   }

--- a/trufflescripts/buy_order.js
+++ b/trufflescripts/buy_order.js
@@ -1,12 +1,14 @@
 const DutchExchangeETHGNO = artifacts.require('./DutchExchangeETHGNO.sol')
 const TokenGNO = artifacts.require('./TokenGNO.sol')
 
-const argv = require('minimist')(process.argv.slice(2))
+const argv = require('minimist')(process.argv.slice(2), { string: 'a' })
 
 /**
  * truffle exec trufflescripts/buy_order.js
- * to post a buy order to the current auction
+ * to post a buy order to the current auction as the buyer
  * @flags:
+ * --seller      as the seller
+ * -a <address>  as the given account
  * --clear       enough to clear an auction
  * -n <number>   for a specific amount
  */
@@ -18,7 +20,12 @@ module.exports = async () => {
 
   const auctionIndex = (await dx.auctionIndex()).toNumber()
 
-  const [, , buyer] = web3.eth.accounts
+  let buyer
+  if (argv.a) buyer = argv.a
+  else if (argv.seller)[, buyer] = web3.eth.accounts
+  else {
+    [, , buyer] = web3.eth.accounts
+  }
 
   const buyerStats = () => Promise.all([
     dx.buyVolumes(auctionIndex),

--- a/trufflescripts/buy_order.js
+++ b/trufflescripts/buy_order.js
@@ -1,0 +1,77 @@
+const DutchExchangeETHGNO = artifacts.require('./DutchExchangeETHGNO.sol')
+const TokenGNO = artifacts.require('./TokenGNO.sol')
+
+const argv = require('minimist')(process.argv.slice(2))
+
+/**
+ * truffle exec trufflescripts/buy_order.js
+ * to post a buy order to the current auction
+ * @flags:
+ * --clear       enough to clear an auction
+ * -n <number>   for a specific amount
+ */
+
+
+module.exports = async () => {
+  const dx = await DutchExchangeETHGNO.deployed()
+  const gno = await TokenGNO.deployed()
+
+  const auctionIndex = (await dx.auctionIndex()).toNumber()
+
+  const [, , buyer] = web3.eth.accounts
+
+  const buyerStats = () => Promise.all([
+    dx.buyVolumes(auctionIndex),
+    dx.buyerBalances(auctionIndex, buyer),
+    gno.balanceOf(buyer),
+  ]).then(res => res.map(n => n.toNumber()))
+
+  let [buyVolume, buyerBalance, buyerGNOBalance] = await buyerStats()
+
+  console.log(`Auction index ${auctionIndex}
+    was:
+    buyVolume:\t${buyVolume}
+    buyerBalance:\t${buyerBalance} in auction
+    \t\t${buyerGNOBalance} GNO in account
+  `)
+
+  try {
+    let amount
+
+    const [nom, den] = (await dx.getPrice(auctionIndex)).map(n => n.toNumber())
+    const sellVolumeCurrent = (await dx.sellVolumeCurrent()).toNumber()
+
+    const amountToClearAuction = Math.floor(sellVolumeCurrent * nom / den) - buyVolume
+
+    if (argv.clear) {
+      console.log(`
+        Posting order for ${amountToClearAuction},
+        enough to clear the auction
+      `)
+      amount = amountToClearAuction
+    } else if (argv.n !== undefined) {
+      amount = argv.n
+      const diff = argv.n - amountToClearAuction
+      console.log(`
+      Posting order for ${argv.n},
+      ${diff >= 0 ? `which is ${diff} more than needed to clear the auction` : ''}
+    `)
+    } else {
+      console.warn('No amount provided')
+      return
+    }
+
+    await gno.approve(dx.address, amount, { from: buyer })
+    await dx.postBuyOrder(amount, 1, { from: buyer })
+  } catch (error) {
+    console.error(error.message || error)
+  }
+
+  [buyVolume, buyerBalance, buyerGNOBalance] = await buyerStats()
+
+  console.log(`now:
+  buyVolume:\t${buyVolume}
+  buyerBalance:\t${buyerBalance} in auction
+  \t\t${buyerGNOBalance} GNO in account
+`)
+}

--- a/trufflescripts/buy_order.js
+++ b/trufflescripts/buy_order.js
@@ -45,10 +45,10 @@ module.exports = async () => {
   try {
     let amount
 
-    const [nom, den] = (await dx.getPrice(auctionIndex)).map(n => n.toNumber())
+    const [num, den] = (await dx.getPrice(auctionIndex)).map(n => n.toNumber())
     const sellVolumeCurrent = (await dx.sellVolumeCurrent()).toNumber()
 
-    const amountToClearAuction = Math.floor(sellVolumeCurrent * nom / den) - buyVolume
+    const amountToClearAuction = Math.floor(sellVolumeCurrent * num / den) - buyVolume
 
     if (argv.clear) {
       console.log(`

--- a/trufflescripts/claim_funds.js
+++ b/trufflescripts/claim_funds.js
@@ -68,6 +68,8 @@ module.exports = async () => {
     }
   }
 
+  console.log(`in auction ${auctionIndex}`)
+
   if (argv.seller) {
     await printSeller()
   } else if (argv.buyer) {

--- a/trufflescripts/claim_funds.js
+++ b/trufflescripts/claim_funds.js
@@ -1,0 +1,79 @@
+const DutchExchangeETHGNO = artifacts.require('./DutchExchangeETHGNO.sol')
+
+const argv = require('minimist')(process.argv.slice(2))
+
+/**
+ * truffle exec trufflescripts/claim_funds.js
+ * to claim funds for the current auction for both seller and buyer
+ * @flags:
+ * --seller     for seller only
+ * --buyer      for buyer only
+ * -i <index>   for auction with given index
+ */
+
+module.exports = async () => {
+  const dx = await DutchExchangeETHGNO.deployed()
+
+  const auctionIndex = argv.i !== undefined ? argv.i : (await dx.auctionIndex()).toNumber()
+
+  const [, seller, buyer] = web3.eth.accounts
+
+  const sellerStats = () => Promise.all([
+    dx.sellerBalances(auctionIndex, seller),
+    dx.claimedAmounts(auctionIndex, seller),
+  ]).then(res => res.map(n => n.toNumber()))
+
+  const buyerStats = () => Promise.all([
+    dx.buyerBalances(auctionIndex, buyer),
+    dx.claimedAmounts(auctionIndex, buyer),
+  ]).then(res => res.map(n => n.toNumber()))
+
+  const printSeller = async () => {
+    let [sellerBalance, sellerClaimed] = await sellerStats()
+
+    console.log(`
+    Seller\tbalance\tclaimed
+    was:\t${sellerBalance}\t${sellerClaimed}`)
+
+    try {
+      const receipt = await dx.claimSellerFunds(auctionIndex, { from: seller })
+      console.log(Object.keys(receipt));
+
+      [sellerBalance, sellerClaimed] = await sellerStats()
+
+      console.log(`    is:\t\t${sellerBalance}\t${sellerClaimed}`)
+    } catch (error) {
+      console.error(error.message || error)
+    }
+
+  }
+
+  const printBuyer = async () => {
+    let [buyerBalance, buyerClaimed] = await buyerStats()
+
+    console.log(`
+    Buyer\tbalance\tclaimed
+    was:\t${buyerBalance}\t${buyerClaimed}
+    `)
+
+    try {
+
+      const receipt = await dx.claimBuyerFunds(auctionIndex, { from: buyer })
+      console.log(Object.keys(receipt));
+
+      [buyerBalance, buyerClaimed] = await buyerStats()
+      console.log(`is:  ${buyerBalance} ${buyerClaimed}`)
+    } catch (error) {
+      console.error(error.message || error)
+    }
+  }
+
+  if (argv.seller) {
+    await printSeller()
+  } else if (argv.buyer) {
+    await printBuyer()
+  } else {
+    await printSeller()
+    await printBuyer()
+  }
+}

--- a/trufflescripts/claim_funds.js
+++ b/trufflescripts/claim_funds.js
@@ -9,12 +9,14 @@ const argv = require('minimist')(process.argv.slice(2))
  * --seller     for seller only
  * --buyer      for buyer only
  * -i <index>   for auction with given index
+ * --last       for last auction
  */
 
 module.exports = async () => {
   const dx = await DutchExchangeETHGNO.deployed()
 
-  const auctionIndex = argv.i !== undefined ? argv.i : (await dx.auctionIndex()).toNumber()
+  let auctionIndex = argv.i !== undefined ? argv.i : (await dx.auctionIndex()).toNumber()
+  if (argv.i === undefined && argv.last) auctionIndex -= 1
 
   const [, seller, buyer] = web3.eth.accounts
 
@@ -36,8 +38,7 @@ module.exports = async () => {
     was:\t${sellerBalance}\t${sellerClaimed}`)
 
     try {
-      const receipt = await dx.claimSellerFunds(auctionIndex, { from: seller })
-      console.log(Object.keys(receipt));
+      await dx.claimSellerFunds(auctionIndex, { from: seller });
 
       [sellerBalance, sellerClaimed] = await sellerStats()
 
@@ -58,11 +59,10 @@ module.exports = async () => {
 
     try {
 
-      const receipt = await dx.claimBuyerFunds(auctionIndex, { from: buyer })
-      console.log(Object.keys(receipt));
+      await dx.claimBuyerFunds(auctionIndex, { from: buyer });
 
       [buyerBalance, buyerClaimed] = await buyerStats()
-      console.log(`is:  ${buyerBalance} ${buyerClaimed}`)
+      console.log(`    is:  ${buyerBalance} ${buyerClaimed}`)
     } catch (error) {
       console.error(error.message || error)
     }

--- a/trufflescripts/get_account_balances.js
+++ b/trufflescripts/get_account_balances.js
@@ -1,6 +1,15 @@
 const TokenETH = artifacts.require('./TokenETH.sol')
 const TokenGNO = artifacts.require('./TokenGNO.sol')
 
+const argv = require('minimist')(process.argv.slice(2), { string: 'a' })
+
+/**
+ * truffle exec trufflescripts/get_account_balances.js
+ * get ETH and GNO balances for seller and buyer accounts
+ * @flags:
+ * -a <address>       and for the given account
+ */
+
 module.exports = async () => {
   // web3 is available in the global context
   const [, seller, buyer] = web3.eth.accounts
@@ -16,4 +25,12 @@ module.exports = async () => {
 
   console.log(`Seller:\t${sellerETHBalance}\tETH,\t${sellerGNOBalance}\tGNO`)
   console.log(`Buyer:\t${buyerETHBalance}\tETH,\t${buyerGNOBalance}\tGNO`)
+
+  if (argv.a) {
+    const accountETHBalance = (await eth.balanceOf(argv.a)).toNumber()
+    const accountGNOBalance = (await gno.balanceOf(argv.a)).toNumber()
+
+    console.log(`\nAccount at ${argv.a} address`)
+    console.log(`Balance:\t${accountETHBalance}\tETH,\t${accountGNOBalance}\tGNO`)
+  }
 }

--- a/trufflescripts/get_auction_stats.js
+++ b/trufflescripts/get_auction_stats.js
@@ -9,6 +9,11 @@ const getTimeStr = (timestamp) => {
   return `${hh ? `${hh} hour(s) ` : ''}${mm ? `${mm} minute(s) ` : ''}${ss ? `${ss} second(s) ` : ''}`
 }
 
+/**
+ * truffle exec trufflescripts/get_auction_stats.js
+ * prints stats for the current and past auctions
+ */
+
 module.exports = async () => {
   const dx = await DutchExchangeETHGNO.deployed()
   const auctionStart = (await dx.auctionStart()).toNumber()

--- a/trufflescripts/get_auction_stats.js
+++ b/trufflescripts/get_auction_stats.js
@@ -10,6 +10,7 @@ const getTimeStr = (timestamp) => {
 }
 
 module.exports = async () => {
+  console.log(process.argv.slice(4))
   const dx = await DutchExchangeETHGNO.deployed()
   const auctionStart = (await dx.auctionStart()).toNumber()
   const now = (await dx.now()).toNumber()

--- a/trufflescripts/get_auction_stats.js
+++ b/trufflescripts/get_auction_stats.js
@@ -50,12 +50,12 @@ Current auction index ${auctionIndex}
 
     let price, amountToClearAuction, timeUntilAuctionClears
     try {
-      const [nom, den] = (await dx.getPrice(i)).map(n => n.toNumber())
-      price = `${nom}/${den}`
+      const [num, den] = (await dx.getPrice(i)).map(n => n.toNumber())
+      price = `1 ETH = ${(num / den).toFixed(8)} GNO`
 
       // if current running auction
       if (i === auctionIndex) {
-        amountToClearAuction = Math.floor(sellVolumeCurrent * nom / den) - buyVolume
+        amountToClearAuction = Math.floor(sellVolumeCurrent * num / den) - buyVolume
         const timeWhenAuctionClears = Math.ceil(72000 * sellVolumeCurrent / buyVolume - 18000 + auctionStart)
 
         timeUntilAuctionClears = getTimeStr((now - timeWhenAuctionClears) * 1000)
@@ -63,8 +63,8 @@ Current auction index ${auctionIndex}
     } catch (error) {
       price = 'unavailable, auction hasn\'t started'
 
-      const [nom, den] = (await dx.getPrice(i - 1)).map(n => n.toNumber())
-      price += `\n  last closingPrice:\t${nom}/${den}`
+      const [num, den] = (await dx.getPrice(i - 1)).map(n => n.toNumber())
+      price += `\n  last closingPrice:\t1 ETH = ${(num / den).toFixed(8)} GNO`
     }
 
     const sellerBalance = (await dx.sellerBalances(i, seller)).toNumber()

--- a/trufflescripts/give_tokens.js
+++ b/trufflescripts/give_tokens.js
@@ -1,0 +1,59 @@
+const TokenETH = artifacts.require('./TokenETH.sol')
+const TokenGNO = artifacts.require('./TokenGNO.sol')
+
+const argv = require('minimist')(process.argv.slice(2), { string: 'a' })
+
+/**
+ * truffle exec trufflescripts/give_tokens.js
+ * give tokens from master
+ * @flags:
+ * --seller           to seller
+ * --buyer            to buyer
+ * -a <address>       to the given address
+ * --eth <number>     ETH tokens
+ * --gno <number>     GNO tokens
+ */
+
+module.exports = async () => {
+  if (!(argv.eth || argv.gno) || !(argv.seller || argv.buyer || argv.a)) {
+    console.warn('No tokens or accounts specified')
+    return
+  }
+
+  // web3 is available in the global context
+  const [master, seller, buyer] = web3.eth.accounts
+  const account = argv.seller ? seller : argv.buyer ? buyer : argv.a
+  const accountName = argv.seller ? 'Seller' : argv.buyer ? 'Buyer' : `Acc ${argv.a}`
+
+  const eth = await TokenETH.deployed()
+  const gno = await TokenGNO.deployed()
+
+  const getBalances = acc => Promise.all([
+    eth.balanceOf(acc),
+    gno.balanceOf(acc),
+  ]).then(res => res.map(n => n.toNumber()))
+
+  console.log(`${accountName}\tETH\tGNO`)
+
+  let [accountETH, accountGNO] = await getBalances(account)
+  console.log(`Balance was:\t${accountETH}\t${accountGNO}`)
+
+  if (argv.eth) {
+    try {
+      await eth.transfer(account, argv.eth, { from: master })
+    } catch (error) {
+      console.error(error.message || error)
+    }
+  }
+
+  if (argv.gno) {
+    try {
+      await gno.transfer(account, argv.gno, { from: master })
+    } catch (error) {
+      console.error(error.message || error)
+    }
+  }
+
+  [accountETH, accountGNO] = await getBalances(account)
+  console.log(`Balance is:\t${accountETH}\t${accountGNO}`)
+}

--- a/trufflescripts/increase_time.js
+++ b/trufflescripts/increase_time.js
@@ -1,0 +1,85 @@
+const DutchExchangeETHGNO = artifacts.require('./DutchExchangeETHGNO.sol')
+
+const argv = require('minimist')(process.argv.slice(2))
+
+const getTimeStr = (timestamp) => {
+  const date = new Date(Math.abs(timestamp))
+  const hh = date.getUTCHours()
+  const mm = date.getUTCMinutes()
+  const ss = date.getUTCSeconds()
+
+  return `${hh ? `${hh} hour(s) ` : ''}${mm ? `${mm} minute(s) ` : ''}${ss ? `${ss} second(s) ` : ''}`
+}
+
+const getSeconds = ({ h = 0, m = 0, s = 0 }) => (h * 60 * 60) + (m * 60) + s
+
+/**
+ * truffle exec trufflescripts/increase_timer.js
+ * increases auction time
+ * @flags:
+ * --start      first, sets time to auction start
+ * --clear      or auction end,
+ * then increases time by
+ * -h <number>    given hours
+ * -m <number>    given minutes
+ * -s <number>    given seconds
+ */
+
+module.exports = async () => {
+  const dx = await DutchExchangeETHGNO.deployed()
+
+  const printAuctionTimes = async () => {
+    const auctionStart = (await dx.auctionStart()).toNumber()
+    const now = (await dx.now()).toNumber()
+
+    const timeUntilStart = auctionStart - now
+    const timeStr = getTimeStr(timeUntilStart * 1000)
+
+    const auctionIndex = (await dx.auctionIndex()).toNumber()
+
+    console.log(`
+  Current auction index ${auctionIndex}
+    ______________________________________
+    now:\t\t\t${new Date(now * 1000).toTimeString()}
+    auctionStart:\t\t${new Date(auctionStart * 1000).toTimeString()}
+    ${timeUntilStart > 0 ? `starts in\t\t${timeStr}` : timeUntilStart < 0 ? `started\t\t${timeStr}ago` : 'just started'}
+  
+    `)
+
+    let timeWhenAuctionClears
+
+    if (timeUntilStart <= 0) {
+      const buyVolume = (await dx.buyVolumes(auctionIndex)).toNumber()
+      const sellVolume = (await dx.sellVolumeCurrent()).toNumber()
+
+      // Auction clears when sellVolume * price = buyVolume
+      timeWhenAuctionClears = Math.ceil(72000 * sellVolume / buyVolume - 18000 + auctionStart)
+      if (timeWhenAuctionClears !== Infinity) {
+        const timeUntilAuctionClears = now - timeWhenAuctionClears
+        console.log(`will clear with time in ${getTimeStr(timeUntilAuctionClears * 1000)}`)
+      }
+    }
+
+    return { auctionStart, timeWhenAuctionClears }
+  }
+
+  const { auctionStart, timeWhenAuctionClears } = await printAuctionTimes()
+
+  const incTimeBy = getSeconds(argv)
+
+  console.log(`Setting time to ${argv.start ? 'AUCTION_START' : argv.clear ? 'AUCTION_END' : ''} ${incTimeBy ? `+ ${getTimeStr(incTimeBy * 1000)}` : ''}`)
+
+  if (argv.start) {
+    await dx.setTime(auctionStart)
+  } else if (argv.clear && timeWhenAuctionClears !== Infinity) {
+    await dx.setTime(timeWhenAuctionClears)
+  }
+
+  if (incTimeBy) {
+    await dx.increaseTimeBy(0, incTimeBy)
+  }
+
+  console.log('==========================')
+
+  await printAuctionTimes()
+}

--- a/trufflescripts/sell_order.js
+++ b/trufflescripts/sell_order.js
@@ -8,7 +8,6 @@ const argv = require('minimist')(process.argv.slice(2))
  * to post a buy order to the current auction
  * @flags:
  * -n <number>   for a specific amount
- * -i <index>    to auction with given index
  */
 
 
@@ -16,9 +15,9 @@ module.exports = async () => {
   const dx = await DutchExchangeETHGNO.deployed()
   const eth = await TokenETH.deployed()
 
-  const auctionIndex = argv.i !== undefined ? argv.i : (await dx.auctionIndex()).toNumber()
+  const auctionIndex = (await dx.auctionIndex()).toNumber()
 
-  const [, , seller] = web3.eth.accounts
+  const [, seller] = web3.eth.accounts
 
   const sellerStats = () => Promise.all([
     dx.sellVolumeCurrent(),
@@ -30,11 +29,11 @@ module.exports = async () => {
   let [sellVolumeCurrent, sellVolumeNext, sellerBalance, sellerETHBalance] = await sellerStats()
 
   console.log(`Auction index ${auctionIndex}
-    was:
+  was:
     sellVolumeCurrent:\t${sellVolumeCurrent}
     sellVolumeNext:\t${sellVolumeNext}
     sellerBalance:\t${sellerBalance} in auction
-    \t\t${sellerETHBalance} ETH in account
+    \t\t\t${sellerETHBalance} ETH in account
   `)
 
   if (argv.n === undefined) {
@@ -44,18 +43,17 @@ module.exports = async () => {
 
   try {
     await eth.approve(dx.address, argv.n, { from: seller })
-    const receipt = await dx.postSellOrder(argv.n, 1, { from: seller })
-    console.log(receipt)
+    await dx.postSellOrder(argv.n, { from: seller })
   } catch (error) {
     console.error(error.message || error)
   }
 
   [sellVolumeCurrent, sellVolumeNext, sellerBalance, sellerETHBalance] = await sellerStats()
 
-  console.log(`now:
-  sellVolumeCurrent:\t${sellVolumeCurrent}
-  sellVolumeNext:\t${sellVolumeNext}
-  sellerBalance:\t${sellerBalance} in auction
-  \t\t${sellerETHBalance} ETH in account
+  console.log(`  now:
+    sellVolumeCurrent:\t${sellVolumeCurrent}
+    sellVolumeNext:\t${sellVolumeNext}
+    sellerBalance:\t${sellerBalance} in auction
+    \t\t\t${sellerETHBalance} ETH in account
 `)
 }

--- a/trufflescripts/sell_order.js
+++ b/trufflescripts/sell_order.js
@@ -1,0 +1,61 @@
+const DutchExchangeETHGNO = artifacts.require('./DutchExchangeETHGNO.sol')
+const TokenETH = artifacts.require('./TokenETH.sol')
+
+const argv = require('minimist')(process.argv.slice(2))
+
+/**
+ * truffle exec trufflescripts/buy_order.js
+ * to post a buy order to the current auction
+ * @flags:
+ * -n <number>   for a specific amount
+ * -i <index>    to auction with given index
+ */
+
+
+module.exports = async () => {
+  const dx = await DutchExchangeETHGNO.deployed()
+  const eth = await TokenETH.deployed()
+
+  const auctionIndex = argv.i !== undefined ? argv.i : (await dx.auctionIndex()).toNumber()
+
+  const [, , seller] = web3.eth.accounts
+
+  const sellerStats = () => Promise.all([
+    dx.sellVolumeCurrent(),
+    dx.sellVolumeNext(),
+    dx.sellerBalances(auctionIndex, seller),
+    eth.balanceOf(seller),
+  ]).then(res => res.map(n => n.toNumber()))
+
+  let [sellVolumeCurrent, sellVolumeNext, sellerBalance, sellerETHBalance] = await sellerStats()
+
+  console.log(`Auction index ${auctionIndex}
+    was:
+    sellVolumeCurrent:\t${sellVolumeCurrent}
+    sellVolumeNext:\t${sellVolumeNext}
+    sellerBalance:\t${sellerBalance} in auction
+    \t\t${sellerETHBalance} ETH in account
+  `)
+
+  if (argv.n === undefined) {
+    console.warn('No amount provided')
+    return
+  }
+
+  try {
+    await eth.approve(dx.address, argv.n, { from: seller })
+    const receipt = await dx.postSellOrder(argv.n, 1, { from: seller })
+    console.log(receipt)
+  } catch (error) {
+    console.error(error.message || error)
+  }
+
+  [sellVolumeCurrent, sellVolumeNext, sellerBalance, sellerETHBalance] = await sellerStats()
+
+  console.log(`now:
+  sellVolumeCurrent:\t${sellVolumeCurrent}
+  sellVolumeNext:\t${sellVolumeNext}
+  sellerBalance:\t${sellerBalance} in auction
+  \t\t${sellerETHBalance} ETH in account
+`)
+}

--- a/trufflescripts/sell_order.js
+++ b/trufflescripts/sell_order.js
@@ -1,13 +1,15 @@
 const DutchExchangeETHGNO = artifacts.require('./DutchExchangeETHGNO.sol')
 const TokenETH = artifacts.require('./TokenETH.sol')
 
-const argv = require('minimist')(process.argv.slice(2))
+const argv = require('minimist')(process.argv.slice(2), { string: 'a' })
 
 /**
  * truffle exec trufflescripts/buy_order.js
- * to post a buy order to the current auction
+ * to post a buy order to the current auction as the seller
  * @flags:
  * -n <number>   for a specific amount
+ * --buyer      as the buyer
+ * -a <address>  as the given account
  */
 
 
@@ -17,7 +19,12 @@ module.exports = async () => {
 
   const auctionIndex = (await dx.auctionIndex()).toNumber()
 
-  const [, seller] = web3.eth.accounts
+  let seller
+  if (argv.a) seller = argv.a
+  else if (argv.buyer)[, , seller] = web3.eth.accounts
+  else {
+    [, seller] = web3.eth.accounts
+  }
 
   const sellerStats = () => Promise.all([
     dx.sellVolumeCurrent(),

--- a/trufflescripts/start_auction.js
+++ b/trufflescripts/start_auction.js
@@ -1,5 +1,11 @@
 const DutchExchangeETHGNO = artifacts.require('./DutchExchangeETHGNO.sol')
 
+/**
+ * truffle exec trufflescripts/start_auction.js
+ * if auction isn't running,
+ * sets time to auction start + 1 hour
+ */
+
 module.exports = async () => {
   const dx = await DutchExchangeETHGNO.deployed()
   const auctionStart = (await dx.auctionStart()).toNumber()

--- a/trufflescripts/topup_accounts.js
+++ b/trufflescripts/topup_accounts.js
@@ -4,6 +4,11 @@ const TokenGNO = artifacts.require('./TokenGNO.sol')
 const sellerETH = 100
 const buyerGNO = 1000
 
+/**
+ * truffle exec trufflescripts/topup_accounts.js
+ * transfers seller 100 RTH and buyer 1000 GNO from master account
+ */
+
 module.exports = async () => {
   // web3 is available in the global context
   const [master, seller, buyer] = web3.eth.accounts


### PR DESCRIPTION
Added more script. Now can simulate the whole auction process.

1. check balances
`truffle exec trufflescripts/get_account_balances.js `
2. give tokens as needed, e.g.
`truffle exec trufflescripts/give_tokens.js --buyer --gno 200`
or
`truffle exec trufflescripts/topup_accounts.js`
3. check auction
`truffle exec trufflescripts/get_auction_stats.js`
3. post sell order
`truffle exec trufflescripts/sell_order.js -n 10`
4. start auction
`truffle exec trufflescripts/start_auction.js`
or
`truffle exec trufflescripts/increase_time.js --start`
5. post buy order
`truffle exec trufflescripts/buy_order.js -n 10`
6. set auction time to auction end (that is when next buy order would cause overflow and auction clearing)
`truffle exec trufflescripts/increase_time.js --start`
or clear auction with buy order outright
`truffle exec trufflescripts/buy_order.js --clear`
7. if you just set time, cause overflow wit any buy order
`truffle exec trufflescripts/buy_order.js -n 1`
8. check that auction cleared and auctionIndex is increased
`truffle exec trufflescripts/get_auction_stats.js`
9. check balances
`truffle exec trufflescripts/get_account_balances.js `
10. claim funds for just finished auction
`truffle exec trufflescripts/claim_funds.js --last`
