### PR TITLE
added getPriceForJS and getPriceOracleForJS

### DIFF
--- a/contracts/DutchExchange.sol
+++ b/contracts/DutchExchange.sol
@@ -646,7 +646,20 @@ contract DutchExchange {
             price.den = (timeElapsed + 43200) * sellTokenPrice.den * buyTokenPrice.num;
         }
     }
-    
+
+    // > getPriceForJs()
+    function getPriceForJS(
+        address sellToken,
+        address buyToken,
+        uint auctionIndex
+    )
+    public
+    constant
+    returns (uint, uint) 
+    {
+        fraction memory price = getPrice(sellToken, buyToken, auctionIndex);
+        return (price.num, price.den);
+    }
     // > clearAuction()
     /// @dev clears an Auction
     /// @param sellToken sellToken of the auction
@@ -853,6 +866,19 @@ contract DutchExchange {
             }
         } 
     }
+
+    // > getPriceOracleForJs()
+    function getPriceOracleForJS(
+        address token
+    )
+    public
+    constant
+    returns (uint, uint) 
+    {
+        fraction memory price = priceOracle(token);
+        return (price.num, price.den);
+    }
+
     function testing(address token)
     public
     returns(uint){


### PR DESCRIPTION
this is due to the fact that we can not yet migrate to 4.19 ipo 4.18 and we need to return the structs for testing