### PR TITLE
Tests/stop watching events

### DIFF
--- a/test/dutchExchange.js
+++ b/test/dutchExchange.js
@@ -60,6 +60,8 @@ contract('DutchExchange', (accounts) => {
     )
   })
 
+  after(() => eventWatcher.stopWatching())
+
   it('Buys tokens at the 2:1 price', async () => {
     eventWatcher(dx, 'NewTokenPair', {})
     
@@ -141,6 +143,8 @@ contract('DutchExchange', (accounts) => {
     )
   })
 
+  after(() => eventWatcher.stopWatching())
+
   it('process two auctions one after the other in one pair only', async () => {
     let auctionIndex
 
@@ -201,6 +205,8 @@ contract('DutchExchange', (accounts) => {
       { from: seller1 },
     )
   })
+
+  after(() => eventWatcher.stopWatching())
 
   it('test a trade on the opposite pair', async () => {
     let auctionIndex

--- a/test/dutchExchange.js
+++ b/test/dutchExchange.js
@@ -60,7 +60,7 @@ contract('DutchExchange', (accounts) => {
     )
   })
 
-  after(() => eventWatcher.stopWatching())
+  after(eventWatcher.stopWatching)
 
   it('Buys tokens at the 2:1 price', async () => {
     eventWatcher(dx, 'NewTokenPair', {})
@@ -143,7 +143,7 @@ contract('DutchExchange', (accounts) => {
     )
   })
 
-  after(() => eventWatcher.stopWatching())
+  after(eventWatcher.stopWatching)
 
   it('process two auctions one after the other in one pair only', async () => {
     let auctionIndex
@@ -206,7 +206,7 @@ contract('DutchExchange', (accounts) => {
     )
   })
 
-  after(() => eventWatcher.stopWatching())
+  after(eventWatcher.stopWatching)
 
   it('test a trade on the opposite pair', async () => {
     let auctionIndex

--- a/test/utils.js
+++ b/test/utils.js
@@ -53,6 +53,11 @@ eventWatcher.stopWatching = (event) => {
     stopWatching[key]()
     delete stopWatching[key]
   }
+
+  // allow to be used as a direct input to mocha hooks (event === done callback)
+  if (typeof event === 'function') {
+    event()
+  }
 }
 
 module.exports = {

--- a/test/utils.js
+++ b/test/utils.js
@@ -17,13 +17,43 @@ const blockNumber = () => web3.eth.blockNumber
 const timestamp = (block = 'latest') => web3.eth.getBlock(block).timestamp
 
 const logger = async (desc, fn) => console.log(`---- \n => ${desc} ${fn ? `|| - - - - - - - - - -  - > ${fn}` : ''}`)
+
+// keeps track of watched events
+const stopWatching = {}
 /**
  * eventWatcher                - ...watches events
  * @param {contract} contract  - dx, usually
  * @param {string} event       - name of event on DutchExchange.sol to track
  * @param {Object} args?       - not required, args to look for
+ * @returns stopWatching function
  */
-const eventWatcher = (contract, event, args) => contract[event](args).watch((err, result) => err ? console.log(err) : console.log('Found', result))
+const eventWatcher = (contract, event, args) => {
+  const eventObject = contract[event](args).watch((err, result) => err ? console.log(err) : console.log('Found', result))
+  const unwatch = stopWatching[event] = eventObject.stopWatching.bind(eventObject)
+
+  return unwatch
+}
+
+eventWatcher.stopWatching = (event) => {
+  // if given particular event name, stop watching it
+  if (event && typeof event === 'string') {
+    const unwatch = stopWatching[event]
+    if (unwatch) {
+      unwatch()
+      delete stopWatching[event]
+    } else {
+      console.log(`${event} event was never watched`)
+    }
+
+    return
+  }
+
+  // otherwise stop watching all events
+  for (const key of Object.keys(stopWatching)) {
+    stopWatching[key]()
+    delete stopWatching[key]
+  }
+}
 
 module.exports = {
   assertRejects,


### PR DESCRIPTION
Stops watching events after tests have run. No need to `Ctrl+C` now.