### PR TITLE
Tests/fuzzy/assert rejects

### DIFF
--- a/test/dutchExchange.js
+++ b/test/dutchExchange.js
@@ -218,9 +218,9 @@ contract('DutchExchange', (accounts) => {
     auctionIndex = await getAuctionIndex()
     await waitUntilPriceIsXPercentOfPreviousPrice(eth, gno, 1)
     await dx.postBuyOrder(eth.address, gno.address, auctionIndex, 10 ** 9 * 2, { from: buyer1 })
-    console.log('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~');
-    console.log('this one isnt working right?',);
-    console.log('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~');
+    console.log('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
+    console.log('this one isnt working right?')
+    console.log('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
     await dx.postBuyOrder(gno.address, eth.address, auctionIndex, 10 ** 7 * 25, { from: seller2 })
     logger('startingReclaiming')
     logger('dx.getPrice.num eth gno', await dx.testing2.call(eth.address, gno.address, auctionIndex))

--- a/test/fuzzy.js
+++ b/test/fuzzy.js
@@ -11,7 +11,7 @@ const [
   DutchExchange,
   EtherToken,
   PriceOracle,
-  PriceOracleInterface,
+  PriceOracleInterface, // eslint-disable-line
   TokenGNO,
   TokenTUL,
 ] = ['DutchExchange', 'EtherToken', 'PriceOracle', 'PriceOracleInterface', 'TokenGNO', 'TokenTUL'].map(c => artifacts.require(c))
@@ -24,34 +24,191 @@ let eth
 let gno
 let dx
 let oracle
-let tokenTUL
+let tokenTUL // eslint-disable-line
 
 // > Other Variables
 // Variables must be at top so they are referencable
 const tokenPairs = []
 
-const approvedTokens = []
+// const approvedTokens = []
 
-contract('DutchExchange', async (accounts) => {
-  it('sets up tests', async () => {
-    await setupTest(accounts)
-  })
-
-  for (let j = 0; j < 50; j++) {
-    it(`above transaction, number ${j.toString()}`, async () => {
-      const t = await selectTransaction()
-      console.log(t[0])
-      wait(1800)
-      await anotherTransaction(accounts, t, j)
-    })
+function log(arg) {
+  if (typeof arg === 'number') {
+    console.log('failed at', arg)
+  } else if (typeof arg === 'boolean') {
+    if (arg) console.log('successful')
+    else console.log('rejected')
   }
-})
+}
+
+
+async function addTokenPair() { //eslint-disable-line
+
+}
+
+async function updateApprovalOfToken() { //eslint-disable-line
+
+}
+
+async function postSellOrderConditions(i, Ts, Tb, u, aI, am) {
+  if (i === 0) {
+    const bal = (await dx.balances(Ts, u)).toNumber()
+    if (am > bal) { log(i); return false }
+  } else if (i === 1) {
+    const lAI = (await dx.getAuctionIndex(Ts, Tb)).toNumber()
+    if (aI !== lAI) { log(i); return false }
+  } else if (i === 2) {
+    const aS = (await dx.getAuctionStart(Ts, Tb)).toNumber()
+    const time = web3.eth.getBlock('latest').timestamp
+
+    const lAI = (await dx.getAuctionIndex(Ts, Tb)).toNumber()
+
+    if (time < aS || aS === 1) {
+      if (aI !== lAI) { log(i); return false }
+    } else if (aI !== lAI + 1) { log(i); return false }
+  }
+
+  return true
+}
+/**
+ * async postBuyOrderConditions
+ * @param {*} i   = index
+ * @param {*} Ts  = Token to Sell
+ * @param {*} Tb  = Token to Buy
+ * @param {*} u   = ???
+ * @param {*} aI  = Auction index
+ * @param {*} am  = ???
+ */
+async function postBuyOrderConditions(i, Ts, Tb, u, aI, am) { //eslint-disable-line
+  // await doesn't work with switch()...
+  if (i === 0) {
+    const aS = (await dx.getAuctionStart(Ts, Tb)).toNumber()
+    const time = web3.eth.getBlock('latest').timestamp
+    console.log('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
+    console.log('aS, time', aS, time)
+    console.log('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
+    if (aS > time) { log(i); return false }
+  } else if (i === 1) {
+    if (aI <= 0) { log(i); return false }
+  } else if (i === 2) {
+    const lAI = (await dx.getAuctionIndex(Ts, Tb)).toNumber()
+    console.log('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
+    console.log('lAI', lAI)
+    console.log('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
+    if (aI !== lAI) { log(i); return false }
+  } else if (i === 3) {
+    const cP = (await dx.closingPrices(Ts, Tb, aI)).map(x => x.toNumber())
+    console.log('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
+    console.log('cP', cP)
+    console.log('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
+    if (cP[0] !== 0) { log(i); return false }
+  }
+
+  return true
+}
+
+async function postSellOrder(Ts, Tb, u, aI, am) {
+  let expectToPass = true
+  let i = 0
+  while (expectToPass && i < 3) {
+    expectToPass = await postSellOrderConditions(i, Ts, Tb, u, aI, am)
+    i++
+  }
+  log(expectToPass)
+  if (expectToPass) await dx.postSellOrder(Ts, Tb, aI, am, { from: u })
+  else await assertRejects(dx.postSellOrder(Ts, Tb, aI, am, { from: u }), `failing sellOrder(${Ts}, ${Tb}, ${aI}, ${am}) from ${u}`)
+}
+
+async function postBuyOrder(Ts, Tb, u, aI, am, j) {
+  console.log('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
+  console.log('postBuyOrder j', j)
+  console.log('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
+  let expectToPass = true
+  let i = 0
+  while (expectToPass && i < 4) {
+    expectToPass = await postBuyOrderConditions(i, Ts, Tb, u, aI, am)
+    i++
+  }
+  log(expectToPass)
+  if (expectToPass) await dx.postBuyOrder(Ts, Tb, aI, am, { from: u })
+  else assertRejects(dx.postBuyOrder(Ts, Tb, aI, am, { from: u }), `failing buyOrder(${Ts}, ${Tb}, ${aI}, ${am}) from ${u}`)
+}
+
+async function claimSellerFunds(Ts, Tb, u, aI) {
+  await dx.claimSellerFunds(Ts, Tb, u, aI, { from: u })
+}
+
+async function claimBuyerFunds(Ts, Tb, u, aI) {
+  await dx.claimBuyerFunds(Ts, Tb, u, aI, { from: u })
+}
+
+// > anotherTransaction()
+async function anotherTransaction(accounts, t, j) {
+  if (t.length > 2) {
+    // pSO & pBO are handled differently
+    if (t[1] === postSellOrder || t[1] === postBuyOrder) {
+      // find out if should be accepted or rejected
+      await t[1](t[2], t[3], accounts[t[4]], t[5], t[6], j)
+    } else { // so are cSF & cBF
+      // find out if should be accepted or rejected
+      await t[1](t[2], t[3], accounts[t[4]], t[5])
+    }
+  }
+}
+
+// > setupTest()
+async function setupTest(accounts) {
+  gno = await TokenGNO.deployed()
+  eth = await EtherToken.deployed()
+  tokenTUL = await TokenTUL.deployed()
+  dx = await DutchExchange.deployed()
+  oracle = await PriceOracle.deployed()
+
+  await Promise.all(accounts.map((acct) => {
+    if (acct === accounts[0]) return null
+
+    return Promise.all([
+      // deposit ETH into ETH token & approve
+      eth.deposit({ from: acct, value: 10 * ONE }),
+      eth.approve(dx.address, 10 * ONE, { from: acct }),
+
+      // transfer GNO from owner & approve
+      gno.transfer(acct, ONE, { from: accounts[0] }),
+      gno.approve(dx.address, ONE, { from: acct }),
+    ])
+  }))
+
+  // Deposit depends on ABOVE finishing first... so run here
+  await Promise.all(accounts.map((acct) => {
+    if (acct === accounts[0]) return null
+
+    return Promise.all([
+      dx.deposit(eth.address, ONE, { from: acct }),
+      dx.deposit(gno.address, ONE, { from: acct }),
+    ])
+  }))
+
+  // updating the oracle Price. Needs to be changed later to another mechanism
+  await oracle.updateETHUSDPrice(700)
+
+  // add token Pair
+  await dx.addTokenPair(
+    eth.address,
+    gno.address,
+    ONE,
+    0,
+    2,
+    1,
+    { from: accounts[1] },
+  )
+
+  tokenPairs.push([eth.address, gno.address])
+}
 
 // > selectTransaction()
 async function selectTransaction() {
   // const r = Math.floor(Math.random() * 6)
   const r = Math.floor(Math.random() * 2) + 2
-  let fn
   const auctionAction = [
     addTokenPair,
     updateApprovalOfToken,
@@ -60,7 +217,7 @@ async function selectTransaction() {
     claimSellerFunds,
     claimBuyerFunds,
   ]
-  fn = auctionAction[r]
+  const fn = auctionAction[r]
 
   let t
   if (r > 1) {
@@ -68,13 +225,13 @@ async function selectTransaction() {
 
     const tokenPair = tokenPairs[Math.floor(Math.random() * tokenPairs.length)]
     let [Ts, Tb] = tokenPair
-    if (Math.floor(Math.random() * 2) == 1) [Ts, Tb] = [Tb, Ts]
+    if (Math.floor(Math.random() * 2) === 1) [Ts, Tb] = [Tb, Ts]
 
     const lAI = (await dx.getAuctionIndex(Ts, Tb)).toNumber()
     const aI = Math.floor(Math.random() * 3) - 1 + lAI
 
     t = [
-      ,
+      undefined,
       fn,
       Ts,
       Tb,
@@ -96,174 +253,17 @@ async function selectTransaction() {
   return t
 }
 
-async function addTokenPair() {
+contract('DutchExchange', async (accounts) => {
+  it('sets up tests', async () => {
+    await setupTest(accounts)
+  })
 
-}
-
-async function updateApprovalOfToken() {
-
-}
-
-async function postSellOrder(Ts, Tb, u, aI, am) {
-  let expectToPass = true
-  let i = 0
-  while (expectToPass && i < 3) {
-    expectToPass = await postSellOrderConditions(i, Ts, Tb, u, aI, am)
-    i++
+  for (let j = 0; j < 50; j++) {
+    it(`above transaction, number ${j.toString()}`, async () => {
+      const t = await selectTransaction()
+      console.log(t[0])
+      wait(1800)
+      await anotherTransaction(accounts, t, j)
+    })
   }
-  log(expectToPass)
-  if (expectToPass) await dx.postSellOrder(Ts, Tb, aI, am, { from: u })
-    else await assertRejects(dx.postSellOrder(Ts, Tb, aI, am, { from: u }), `failing sellOrder(${Ts}, ${Tb}, ${aI}, ${am}) from ${u}`)
-}
-
-async function postBuyOrder(Ts, Tb, u, aI, am, j) {
-  console.log('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~');
-  console.log('postBuyOrder j',j);
-  console.log('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~');
-  let expectToPass = true
-  let i = 0
-  while (expectToPass && i < 4) {
-    expectToPass = await postBuyOrderConditions(i, Ts, Tb, u, aI, am)
-    i++
-  }
-  log(expectToPass)
-  if (expectToPass) await dx.postBuyOrder(Ts, Tb, aI, am, { from: u })
-    else assertRejects(dx.postBuyOrder(Ts, Tb, aI, am, { from: u }), `failing buyOrder(${Ts}, ${Tb}, ${aI}, ${am}) from ${u}`)
-}
-
-async function claimSellerFunds(Ts, Tb, u, aI) {
-  await dx.claimSellerFunds(Ts, Tb, u, aI, { from: u })
-}
-
-async function claimBuyerFunds(Ts, Tb, u, aI) {
-  await dx.claimBuyerFunds(Ts, Tb, u, aI, { from: u })
-}
-
-// > anotherTransaction()
-async function anotherTransaction(accounts, t, j) {
-  if (t.length > 2) {
-    // pSO & pBO are handled differently
-    if (t[1] === postSellOrder || t[1] === postBuyOrder) {
-      // find out if should be accepted or rejected
-      await t[1](t[2], t[3], accounts[t[4]], t[5], t[6], j)
-    }
-    // so are cSF & cBF
-    else {
-      // find out if should be accepted or rejected
-      await t[1](t[2], t[3], accounts[t[4]], t[5])
-    }
-  }
-}
-
-async function postSellOrderConditions(i, Ts, Tb, u, aI, am) {
-  if (i == 0) {
-    const bal = (await dx.balances(Ts, u)).toNumber()
-    if (am > bal) { log(i); return false }
-  } else if (i == 1) {
-    const lAI = (await dx.getAuctionIndex(Ts, Tb)).toNumber()
-    if (aI !== lAI) { log(i); return false }
-  } else if (i == 2) {
-    const aS = (await dx.getAuctionStart(Ts, Tb)).toNumber()
-    const time = web3.eth.getBlock('latest').timestamp
-
-    const lAI = (await dx.getAuctionIndex(Ts, Tb)).toNumber()
-
-    if (time < aS || aS === 1) {
-      if (aI !== lAI) { log(i); return false }
-    } else {
-      if (aI !== lAI + 1) { log(i); return false }
-    }
-  }
-
-  return true
-}
-/**
- * async postBuyOrderConditions
- * @param {*} i   = index
- * @param {*} Ts  = Token to Sell
- * @param {*} Tb  = Token to Buy
- * @param {*} u   = ???
- * @param {*} aI  = Auction index
- * @param {*} am  = ???
- */
-async function postBuyOrderConditions(i, Ts, Tb, u, aI, am) {
-  // await doesn't work with switch()...
-  if (i == 0) {
-    const aS = (await dx.getAuctionStart(Ts, Tb)).toNumber()
-    const time = web3.eth.getBlock('latest').timestamp
-    console.log('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~');
-    console.log('aS, time', aS, time);
-    console.log('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~');
-    if (aS > time) { log(i); return false }
-  } else if (i == 1) {
-    if (aI <= 0) { log(i); return false }
-  } else if (i == 2) {
-    const lAI = (await dx.getAuctionIndex(Ts, Tb)).toNumber()
-    console.log('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
-    console.log('lAI', lAI)
-    console.log('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
-    if (aI !== lAI) { log(i); return false }
-  } else if (i == 3) {
-    const cP = (await dx.closingPrices(Ts, Tb, aI)).map(x => x.toNumber())
-    console.log('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
-    console.log('cP', cP)
-    console.log('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
-    if (cP[0] !== 0) { log(i); return false }
-  }
-
-  return true
-}
-
-// > setupTest()
-async function setupTest(accounts) {
-  gno = await TokenGNO.deployed()
-  eth = await EtherToken.deployed()
-  tokenTUL = await TokenTUL.deployed() 
-  dx = await DutchExchange.deployed()
-  oracle = await PriceOracle.deployed()
-
-  await Promise.all(accounts.map((acct) => {
-    if (acct === accounts[0]) return
-
-    // deposit ETH into ETH token & approve
-    eth.deposit({ from: acct, value: 10 * ONE })
-    eth.approve(dx.address, 10 * ONE, { from: acct })
-
-    // transfer GNO from owner & approve
-    gno.transfer(acct, ONE, { from: accounts[0] })
-    gno.approve(dx.address, ONE, { from: acct })
-  }))
-
-  // Deposit depends on ABOVE finishing first... so run here
-  await Promise.all(accounts.map((acct) => {
-    if (acct === accounts[0]) return
-
-    dx.deposit(eth.address,  ONE, { from: acct })
-    dx.deposit(gno.address,  ONE, { from: acct })
-  }))
-
-  // updating the oracle Price. Needs to be changed later to another mechanism
-  await oracle.updateETHUSDPrice(700)
-
-  // add token Pair
-  await dx.addTokenPair(
-    eth.address,
-    gno.address,
-    ONE,
-    0,
-    2,
-    1,
-    { from: accounts[1] },
-  )
-
-  tokenPairs.push([eth.address, gno.address])
-}
-
-function log(arg) {
-  if (typeof arg == 'number') {
-    console.log('failed at', arg)
-  } else if (typeof arg == 'boolean') {
-    if (arg) console.log('successful')
-    else console.log('rejected')
-  }
-}
+})

--- a/test/fuzzy.js
+++ b/test/fuzzy.js
@@ -51,25 +51,37 @@ async function updateApprovalOfToken() { //eslint-disable-line
 }
 
 async function postSellOrderConditions(i, Ts, Tb, u, aI, am) {
-  if (i === 0) {
-    const bal = (await dx.balances(Ts, u)).toNumber()
-    if (am > bal) { log(i); return false }
-  } else if (i === 1) {
-    const lAI = (await dx.getAuctionIndex(Ts, Tb)).toNumber()
-    if (aI !== lAI) { log(i); return false }
-  } else if (i === 2) {
-    const aS = (await dx.getAuctionStart(Ts, Tb)).toNumber()
-    const time = web3.eth.getBlock('latest').timestamp
-
-    const lAI = (await dx.getAuctionIndex(Ts, Tb)).toNumber()
-
-    if (time < aS || aS === 1) {
+  switch (i) {
+    case 0:
+    {
+      const bal = (await dx.balances(Ts, u)).toNumber()
+      if (am > bal) { log(i); return false }
+      break
+    }
+    case 1:
+    {
+      const lAI = (await dx.getAuctionIndex(Ts, Tb)).toNumber()
       if (aI !== lAI) { log(i); return false }
-    } else if (aI !== lAI + 1) { log(i); return false }
+      break
+    }
+    case 2:
+    {
+      const aS = (await dx.getAuctionStart(Ts, Tb)).toNumber()
+      const time = web3.eth.getBlock('latest').timestamp
+
+      const lAI = (await dx.getAuctionIndex(Ts, Tb)).toNumber()
+
+      if (time < aS || aS === 1) {
+        if (aI !== lAI) { log(i); return false }
+      } else if (aI !== lAI + 1) { log(i); return false }
+      break
+    }
+    default:
   }
 
   return true
 }
+
 /**
  * async postBuyOrderConditions
  * @param {*} i   = index
@@ -80,28 +92,39 @@ async function postSellOrderConditions(i, Ts, Tb, u, aI, am) {
  * @param {*} am  = ???
  */
 async function postBuyOrderConditions(i, Ts, Tb, u, aI, am) { //eslint-disable-line
-  // await doesn't work with switch()...
-  if (i === 0) {
-    const aS = (await dx.getAuctionStart(Ts, Tb)).toNumber()
-    const time = web3.eth.getBlock('latest').timestamp
-    console.log('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
-    console.log('aS, time', aS, time)
-    console.log('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
-    if (aS > time) { log(i); return false }
-  } else if (i === 1) {
-    if (aI <= 0) { log(i); return false }
-  } else if (i === 2) {
-    const lAI = (await dx.getAuctionIndex(Ts, Tb)).toNumber()
-    console.log('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
-    console.log('lAI', lAI)
-    console.log('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
-    if (aI !== lAI) { log(i); return false }
-  } else if (i === 3) {
-    const cP = (await dx.closingPrices(Ts, Tb, aI)).map(x => x.toNumber())
-    console.log('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
-    console.log('cP', cP)
-    console.log('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
-    if (cP[0] !== 0) { log(i); return false }
+  switch (i) {
+    case 0:
+    {
+      const aS = (await dx.getAuctionStart(Ts, Tb)).toNumber()
+      const time = web3.eth.getBlock('latest').timestamp
+      console.log('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
+      console.log('aS, time', aS, time)
+      console.log('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
+      if (aS > time) { log(i); return false }
+      break
+    }
+    case 1:
+      if (aI <= 0) { log(i); return false }
+      break
+    case 2:
+    {
+      const lAI = (await dx.getAuctionIndex(Ts, Tb)).toNumber()
+      console.log('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
+      console.log('lAI', lAI)
+      console.log('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
+      if (aI !== lAI) { log(i); return false }
+      break
+    }
+    case 3:
+    {
+      const cP = (await dx.closingPrices(Ts, Tb, aI)).map(x => x.toNumber())
+      console.log('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
+      console.log('cP', cP)
+      console.log('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
+      if (cP[0] !== 0) { log(i); return false }
+      break
+    }
+    default:
   }
 
   return true

--- a/test/testFunctions.js
+++ b/test/testFunctions.js
@@ -1,4 +1,4 @@
-/* eslint prefer-const:0, max-len:0, object-curly-newline:1, no-param-reassign:0, no-console:0 */
+/* eslint prefer-const:0, max-len:0, object-curly-newline:1, no-param-reassign:0, no-console:0, no-mixed-operators:0 */
 const { wait } = require('@digix/tempo')(web3)
 const { timestamp, varLogger } = require('./utils')
 
@@ -122,16 +122,16 @@ const checkBalanceBeforeClaim = async (
 
   const balanceBeforeClaim = (await dx.balances.call(token.address, acct)).toNumber()
 
-  if (claiming == 'buyer') {
+  if (claiming === 'buyer') {
     await dx.claimBuyerFunds(sellToken.address, buyToken.address, acct, idx)
   } else {
     await dx.claimSellerFunds(sellToken.address, buyToken.address, acct, idx)
   }
-  
+
   const balanceAfterClaim = (await dx.balances.call(token.address, acct)).toNumber()
   const difference = Math.abs(balanceBeforeClaim + amt - balanceAfterClaim)
   varLogger('claiming for', claiming)
-  varLogger('balanceBeforeClaim', balanceBeforeClaim);
+  varLogger('balanceBeforeClaim', balanceBeforeClaim)
   varLogger('amount', amt)
   varLogger('balanceAfterClaim', balanceAfterClaim)
   varLogger('difference', difference)
@@ -144,7 +144,7 @@ const getAuctionIndex = async (sell, buy) => {
 
   return (await dx.getAuctionIndex.call(buy.address, sell.address)).toNumber()
 }
-const getStartingTimeOfAuction = async (sell = eth, buy = gno) => (await dx.getAuctionStart.call(sell.address, buy.address)).toNumber()
+// const getStartingTimeOfAuction = async (sell = eth, buy = gno) => (await dx.getAuctionStart.call(sell.address, buy.address)).toNumber()
 
 /**
  * address sellToken,

--- a/test/utils.js
+++ b/test/utils.js
@@ -94,12 +94,22 @@ eventWatcher.stopWatching = (contract, event) => {
   }
 }
 
-const wait = seconds => web3.currentProvider.send({
-  jsonrpc: '2.0',
-  method: 'evm_increaseTime',
-  params: [seconds] || [],
-  id: new Date().getTime(),
-})
+const wait = (seconds) => {
+  const id = Date.now()
+  web3.currentProvider.send({
+    jsonrpc: '2.0',
+    method: 'evm_increaseTime',
+    params: [seconds] || [],
+    id,
+  })
+
+  web3.currentProvider.send({
+    jsonrpc: '2.0',
+    method: 'evm_mine',
+    params: [],
+    id: id + 1,
+  })
+}
 
 module.exports = {
   assertRejects,

--- a/test/utils.js
+++ b/test/utils.js
@@ -3,7 +3,8 @@ const assertRejects = async (q, msg) => {
   let res, catchFlag = false
   try {
     res = await q
-    catchFlag = res.logs && !!res.logs.find(log => log.event === 'Log')
+    // checks if there was a Log event and its argument l contains string "R<number>"
+    catchFlag = res.logs && !!res.logs.find(log => log.event === 'Log' && /\bR(\d+\.?)+/.test(log.args.l))
   } catch (e) {
     catchFlag = true
   } finally {

--- a/test/utils.js
+++ b/test/utils.js
@@ -3,6 +3,7 @@ const assertRejects = async (q, msg) => {
   let res, catchFlag = false
   try {
     res = await q
+    catchFlag = res.logs && !!res.logs.find(log => log.event === 'Log')
   } catch (e) {
     catchFlag = true
   } finally {


### PR DESCRIPTION
+ Added recognition of transactions with `Log` event as rejected
+ Fixed linting in fuzzy tests (mainly hoisted functions to the beginning of file)
+ Simplified `if-else` logic
+ Added `evm_mine` instruction after `evm_increaseTime` as timestamp isn't actually increased otherwise


-----------------
+ no changes to test logic

Currently fail up to 8-11 fuzzy tests
To tests only fuzzy tests: `truffle test test/fuzzy.js`
To test without fuzzy tests: `truffle test test/dutchExchange.js test/dutchExchange-Tulip.js`