### PR TITLE
Contracts/helper func for contract flag

### DIFF
--- a/test/dutchExchange-Tulip.js
+++ b/test/dutchExchange-Tulip.js
@@ -11,11 +11,11 @@
 */
 
 // const PriceOracleInterface = artifacts.require('PriceOracleInterface')
-const argv = require('minimist')(process.argv.slice(2), { alias: { selector: 'sel' } })
 const { 
   eventWatcher,
   log,
   timestamp,
+  enableContractFlag,
 } = require('./utils')
 
 const {
@@ -1196,17 +1196,5 @@ const c5 = () => contract('DX Tulip Flow --> 2 Sellers || Tulip issuance', (acco
   })  
 })  
 
-// arg conditionally start contracts
-if (argv.c === 1) {
-  c1()
-} else if (argv.c === 2) {
-  c2()
-} else if (argv.c === 3) {
-  c3()
-} else if (argv.c === 4) {
-  c4()
-} else if (argv.c === 5) {
-  c5()
-} else {
-  [c1, c2, c3, c4, c5].forEach(c => c())
-}
+// conditionally start contracts
+enableContractFlag(c1, c2, c3, c4, c5)

--- a/test/dutchExchange-Tulip.js
+++ b/test/dutchExchange-Tulip.js
@@ -737,6 +737,8 @@ const c3 = () => contract('DX Tulip Flow --> withdrawUnlockedTokens', (accounts)
     log(`\nSeller Balance ====> ${seller1Balance.toEth()}\n`)
     assert.equal(seller1Balance, startingETH - sellingAmount, `Seller1 should have ${startingETH.toEth()} balance after new Token Pair add`)
   })
+
+  afterEach(eventWatcher.stopWatching)
   
   it('Check sellVolume', async () => {
     log(`

--- a/test/dutchExchange-settleFee.js
+++ b/test/dutchExchange-settleFee.js
@@ -2,9 +2,8 @@ const {
   eventWatcher,
   logger,
   log,
+  enableContractFlag,
 } = require('./utils')
-
-const argv = require('minimist')(process.argv.slice(2), { alias: { contract: 'c' } })
 
 const { getContracts, setupTest } = require('./testFunctions')
 
@@ -511,7 +510,4 @@ const c2 = () => contract('DutchExchange - settleFee', (accounts) => {
 })
 
 
-const contractTests = [c1, c2]
-const cTest = contractTests[argv.c - 1]
-if (cTest) cTest()
-else contractTests.forEach(c => c())
+enableContractFlag(c1, c2)

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,6 +1,6 @@
 /* eslint no-console:0, no-confusing-arrow:0 */
 // `truffle test --silent` or `truffle test -s` to suppress logs
-const { silent } = require('minimist')(process.argv.slice(2), { alias: { silent: 's' } })
+const { silent, contract: contractFlag } = require('minimist')(process.argv.slice(2), { alias: { silent: 's', contract: 'c' } })
 
 const assertRejects = async (q, msg) => {
   let res, catchFlag = false
@@ -147,6 +147,12 @@ eventWatcher.stopWatching = (contract, event) => {
   } else unwatchAll()
 }
 
+const enableContractFlag = (...contractTests) => {
+  const cTest = contractTests[contractFlag - 1]
+  if (cTest) cTest()
+  else contractTests.forEach(c => c())
+}
+
 module.exports = {
   assertRejects,
   blockNumber,
@@ -155,4 +161,5 @@ module.exports = {
   log,
   varLogger,
   timestamp,
+  enableContractFlag,
 }


### PR DESCRIPTION
Dynamically running contracts (`truffle test file.js -c1`) can be enabled with:
```
const { enableContractFlag } = require('./utils')

const c1 = () => contract('...', () => {...})
...

enableContractFlag(c1, c2, ...)  // order matters
```