### PR TITLE
Contracts/tests/post sell order

### DIFF
--- a/test/dutchExchange-postSellOrder.js
+++ b/test/dutchExchange-postSellOrder.js
@@ -101,4 +101,16 @@ contract('DutchExchange - postSellOrder', (accounts) => {
 
     await assertRejects(dx.postSellOrder(eth.address, gno.address, 1, amount, { from: seller1 }), 'should reject as resulting amount == 0')
   })
+
+  it('rejects when latestAuctionIndex == 0, i.e. no TokenPair was added', async () => {
+    const latestAuctionIndex = (await dx.getAuctionIndex.call(eth.address, gno.address)).toNumber()
+
+    assert.strictEqual(latestAuctionIndex, 0, 'action hasn\'t run yet')
+
+    const amount = 100
+
+    assert.isAbove(amount, 0, 'amount should be > 0 so as not to trigger reject')
+
+    await assertRejects(dx.postSellOrder(eth.address, gno.address, latestAuctionIndex, amount, { from: seller1 }), 'should reject as latestAuctionIndex == 0')
+  })
 })

--- a/test/dutchExchange-postSellOrder.js
+++ b/test/dutchExchange-postSellOrder.js
@@ -1,0 +1,74 @@
+const {
+  eventWatcher,
+  logger,
+  log,
+} = require('./utils')
+
+const { getContracts, setupTest } = require('./testFunctions')
+
+// Test VARS
+let eth
+let gno
+let tul
+let owl
+let dx
+let oracle
+
+
+let contracts
+
+const separateLogs = () => log('\n    ----------------------------------')
+
+contract('DutchExchange - settleFee', (accounts) => {
+  const [master, seller1] = accounts
+
+  const startBal = {
+    startingETH: 0,
+    startingGNO: 90.0.toWei(),
+    ethUSDPrice: 1008.0.toWei(),
+    sellingAmount: 50.0.toWei(),
+  }
+
+  beforeEach(separateLogs)
+
+  before(async () => {
+    // get contracts
+    contracts = await getContracts();
+    // destructure contracts into upper state
+    ({
+      // DutchExchange: dx,
+      EtherToken: eth,
+      TokenGNO: gno,
+      TokenTUL: tul,
+      TokenOWL: owl,
+      // using internal contract with settleFeePub calling dx.settleFee internally
+      DutchExchange: dx,
+      PriceOracleInterface: oracle,
+    } = contracts)
+
+    await setupTest(accounts, contracts, startBal)
+
+    // add tokenPair ETH GNO
+    // await dx.addTokenPair(
+    //   eth.address,
+    //   gno.address,
+    //   10 * (10 ** 18),
+    //   0,
+    //   2,
+    //   1,
+    //   { from: seller1 },
+    // )
+
+    // await tul.updateMinter(master, { from: master })
+    logger('PRICE ORACLE', await oracle.getUSDETHPrice.call())
+
+    const [sNum, sDen] = await dx.getPriceOracleForJS.call(eth.address)
+    logger('ST PRICE', `${sNum}/${sDen} == ${sNum / sDen}`)
+    const [bNum, bDen] = await dx.getPriceOracleForJS.call(gno.address)
+    logger('BT PRICE', `${bNum}/${bDen} == ${bNum / bDen}`)
+
+    eventWatcher(dx, 'NewSellOrder')
+  })
+
+  after(eventWatcher.stopWatching)
+})

--- a/test/dutchExchange-postSellOrder.js
+++ b/test/dutchExchange-postSellOrder.js
@@ -85,4 +85,20 @@ contract('DutchExchange - postSellOrder', (accounts) => {
 
     await assertRejects(dx.postSellOrder(eth.address, gno.address, 1, amount, { from: seller1 }), 'should reject as resulting amount == 0')
   })
+
+  it('rejects when sellToken amount == 0', async () => {
+    eth.deposit({ from: seller1, value: 100 })
+    await eth.approve(dx.address, 100, { from: seller1 })
+    await dx.deposit(eth.address, 100, { from: seller1 })
+
+    const ethBalance = (await dx.balances.call(eth.address, seller1)).toNumber()
+
+    assert.isAbove(ethBalance, 0, 'account should have some ETH in DX')
+
+    const amount = 0
+
+    assert.strictEqual(amount, 0, 'amount should be 0')
+
+    await assertRejects(dx.postSellOrder(eth.address, gno.address, 1, amount, { from: seller1 }), 'should reject as resulting amount == 0')
+  })
 })

--- a/test/dutchExchange-postSellOrder.js
+++ b/test/dutchExchange-postSellOrder.js
@@ -3,6 +3,7 @@ const {
   log: utilsLog,
   assertRejects,
   timestamp,
+  gasLogger,
 } = require('./utils')
 
 const { getContracts, setupTest, wait } = require('./testFunctions')
@@ -32,6 +33,7 @@ contract('DutchExchange - postSellOrder', (accounts) => {
   }
 
   beforeEach(separateLogs)
+  afterEach(() => gasLogger())
 
   before(async () => {
     // get contracts
@@ -49,7 +51,7 @@ contract('DutchExchange - postSellOrder', (accounts) => {
     eventWatcher(dx, 'NewSellOrder')
     eventWatcher(dx, 'Log')
 
-    const totalTul = (await tul.totalTokens()).toNumber()
+    const totalTul = (await tul.totalTokens.call()).toNumber()
     assert.strictEqual(totalTul, 0, 'total TUL tokens should be 0')
     // then we know that feeRatio = 1 / 200
     feeRatio = 1 / 200

--- a/test/utils.js
+++ b/test/utils.js
@@ -37,8 +37,8 @@ const gasLogWrapper = (contracts) => {
         // called if @transaction function
         async apply(target, thisArg, argumentsList) {
           const result = await Reflect.apply(target, thisArg, argumentsList)
-          // safeguards against constant functions
-          if (typeof result !== 'object') return result
+          // safeguards against constant functions and BigNumber returns
+          if (typeof result !== 'object' || !result.receipt) return result
           const { receipt: { gasUsed } } = result
           // check that BOTH gas flags are used
           gasLog && gasTx && console.info(`

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,6 +1,6 @@
 /* eslint no-console:0, no-confusing-arrow:0 */
 // `truffle test --silent` or `truffle test -s` to suppress logs
-const { silent, contract: contractFlag } = require('minimist')(process.argv.slice(2), { alias: { silent: 's', contract: 'c' } })
+const { silent, contract: contractFlag, noevents } = require('minimist')(process.argv.slice(2), { alias: { silent: 's', contract: 'c' } })
 
 const assertRejects = async (q, msg) => {
   let res, catchFlag = false
@@ -35,7 +35,7 @@ let stopWatching = {}
  * @param {Object} args?       - not required, args to look for
  * @returns stopWatching function
  */
-const eventWatcher = (contract, eventName, argum = {}) => {
+const eventWatcher = noevents ? () => {} : (contract, eventName, argum = {}) => {
   const eventFunc = contract[eventName]
   if (!eventFunc) {
     log(`No event ${eventName} available in the contract`)
@@ -88,7 +88,7 @@ const eventWatcher = (contract, eventName, argum = {}) => {
  * @param {string} event?       - name of event to stop watching,
  *                                if none specified stops watching all events for this contract
  */
-eventWatcher.stopWatching = (contract, event) => {
+eventWatcher.stopWatching = noevents ? () => {} : (contract, event) => {
   // if given particular event name, stop watching it
   if (contract && typeof contract === 'object' && contract.address) {
     const contractEvents = stopWatching[contract.address]


### PR DESCRIPTION
Tests for `postSellOrder` function
Bonus: flag `--noevents` to skip printing event logs