### PR TITLE
Contracts/test/claim buyer funds test

### DIFF
--- a/contracts/DutchExchange.sol
+++ b/contracts/DutchExchange.sol
@@ -925,7 +925,19 @@ contract DutchExchange {
         withdraw(buyToken, amount);
     }
 
-    // > testing fns
+    
+    // > historicalPriceOracleForJs()
+    function historicalPriceOracleForJS(
+        address token,
+        uint auctionIndex
+    )
+    public
+    constant
+    returns (uint, uint) 
+    {
+        fraction memory price = historicalPriceOracle(token, auctionIndex);
+        return (price.num, price.den);
+    }
 
     // > getPriceOracleForJs()
     function getPriceOracleForJS(
@@ -952,6 +964,7 @@ contract DutchExchange {
         fraction memory price = computeRatioOfHistoricalPriceOracles(tokenA, tokenB, auctionIndex);
         return (price.num, price.den);
     }
+
 
     // > helper fns
     function getTokenOrder(

--- a/contracts/DutchExchange.sol
+++ b/contracts/DutchExchange.sol
@@ -939,6 +939,20 @@ contract DutchExchange {
         return (price.num, price.den);
     }
 
+     // > getPriceOracleForJs()
+    function computeRatioOfHistoricalPriceOraclesForJS(
+        address tokenA,
+        address tokenB,
+        uint auctionIndex
+    )
+    public
+    constant
+    returns (uint, uint) 
+    {
+        fraction memory price = computeRatioOfHistoricalPriceOracles(tokenA, tokenB, auctionIndex);
+        return (price.num, price.den);
+    }
+
     // > helper fns
     function getTokenOrder(
         address token1,

--- a/test/dutchExchange-claimBuyerFunds.js
+++ b/test/dutchExchange-claimBuyerFunds.js
@@ -1,0 +1,244 @@
+/* eslint no-console:0, max-len:0, no-plusplus:0, no-mixed-operators:0, no-trailing-spaces:0 */
+
+
+/*
+TUL token issuing will not be covered in these tests, as they are covered in the tulip testing scripts
+*/
+
+const bn = require('bignumber.js')
+
+const { 
+  eventWatcher,
+  assertRejects,
+  logger,
+} = require('./utils')
+
+const {
+  setupTest,
+  getContracts,
+  getAuctionIndex,
+  waitUntilPriceIsXPercentOfPreviousPrice,
+  setAndCheckAuctionStarted,
+  postBuyOrder,
+  postSellOrder,
+} = require('./testFunctions')
+
+// Test VARS
+let eth
+let gno
+let dx
+
+let contracts
+
+const valMinusFee = amount => amount - (amount / 200)
+
+
+const setupContracts = async () => {
+  contracts = await getContracts();
+  // destructure contracts into upper state
+  ({
+    DutchExchange: dx,
+    EtherToken: eth,
+    TokenGNO: gno,
+  } = contracts)
+}
+const startBal = {
+  startingETH: 90.0.toWei(),
+  startingGNO: 90.0.toWei(),
+  ethUSDPrice: 1008.0.toWei(),
+  sellingAmount: 50.0.toWei(), // Same as web3.toWei(50, 'ether')
+}
+
+
+contract('DutchExchange - claimBuyerFunds', (accounts) => {
+  const [, seller1, seller2, buyer1, buyer2] = accounts
+  const totalSellAmount2ndAuction = 10e18
+
+  before(async () => {
+    // get contracts
+    await setupContracts()
+
+    // set up accounts and tokens[contracts]
+    await setupTest(accounts, contracts, startBal)
+
+    // add tokenPair ETH GNO
+    await dx.addTokenPair(
+      eth.address,
+      gno.address,
+      10e18,
+      0,
+      2,
+      1,
+      { from: seller1 },
+    )
+
+    eventWatcher(dx, 'Log', {})
+  })
+
+  after(eventWatcher.stopWatching)
+
+  it('1. check for a throw, if auctionIndex is bigger than the latest auctionIndex', async () => {
+    const auctionIndex = await getAuctionIndex()
+    await setAndCheckAuctionStarted(eth, gno)
+    await waitUntilPriceIsXPercentOfPreviousPrice(eth, gno, 1.5)
+    await assertRejects(dx.claimBuyerFunds(eth.address, gno.address, buyer1, auctionIndex + 1))
+  })
+
+  it(' 2. checks that the return value == 0, if price.num ==0 ', async () => {
+    // prepare test by starting and clearning new auction
+    let auctionIndex = await getAuctionIndex()
+    await postSellOrder(gno, eth, 0, totalSellAmount2ndAuction, seller2)
+    await waitUntilPriceIsXPercentOfPreviousPrice(eth, gno, 1)
+    await postBuyOrder(eth, gno, auctionIndex, 2 * 10e18, buyer1)
+    auctionIndex = await getAuctionIndex()
+    await setAndCheckAuctionStarted(eth, gno)
+    assert.equal(2, auctionIndex)
+
+    // now claiming should not be possible and return == 0
+    await setAndCheckAuctionStarted(eth, gno)
+    await waitUntilPriceIsXPercentOfPreviousPrice(eth, gno, 1.5)
+    const [closingPriceNum] = (await dx.closingPrices.call(gno.address, eth.address, auctionIndex - 1)).map(i => i.toNumber())
+    assert.equal(closingPriceNum, 0)
+    logger('here it is ')
+    const [claimedAmount] = (await dx.claimBuyerFunds.call(gno.address, eth.address, buyer1, auctionIndex)).map(i => i.toNumber())
+    assert.equal(claimedAmount, 0) 
+  })
+  it(' 3. checks that the non buyers can not claim any returns', async () => {
+    const auctionIndex = await getAuctionIndex()
+    const [claimedAmount] = (await dx.claimBuyerFunds.call(eth.address, gno.address, buyer1, auctionIndex)).map(i => i.toNumber())
+    assert.equal(claimedAmount, 0) 
+  })
+
+  it('4. check right amount of coins is returned by claimBuyerFunds if auction is not closed', async () => {
+    const auctionIndex = await getAuctionIndex()
+
+    // prepare test by starting and closing theoretical auction
+    await waitUntilPriceIsXPercentOfPreviousPrice(eth, gno, 1)
+
+    await postBuyOrder(gno, eth, auctionIndex, totalSellAmount2ndAuction / 4, buyer2)
+
+    // checking that closingPriceToken.num == 0
+    const [closingPriceNumToken] = (await dx.closingPrices.call(eth.address, gno.address, auctionIndex)).map(i => i.toNumber())
+    assert.equal(closingPriceNumToken, 0)
+    
+    // actual testing at time with previous price
+    const [claimedAmount] = (await dx.claimBuyerFunds.call(gno.address, eth.address, buyer2, auctionIndex)).map(i => i.toNumber())
+    const [num, den] = (await dx.getPriceForJS.call(gno.address, eth.address, auctionIndex)).map(i => i.toNumber())
+    let sellVolume = (await dx.sellVolumesCurrent.call(gno.address, eth.address))
+    let buyVolume = (await dx.buyVolumes.call(gno.address, eth.address))
+    let oustandingVolume = (sellVolume.mul(bn(num)).toNumber() / den) - (buyVolume).toNumber()
+    logger('oustandingVolume', oustandingVolume)
+    logger('buyVolume', buyVolume)
+    assert.equal((bn(valMinusFee(totalSellAmount2ndAuction)).mul(buyVolume).div(buyVolume.add(oustandingVolume))).toNumber(), claimedAmount)
+
+    // actual testing at time with previous 2/3price
+    await waitUntilPriceIsXPercentOfPreviousPrice(eth, gno, 2 / 3)
+    const [claimedAmount2] = (await dx.claimBuyerFunds.call(gno.address, eth.address, buyer2, auctionIndex)).map(i => i.toNumber())
+    const [num2, den2] = (await dx.getPriceForJS.call(gno.address, eth.address, auctionIndex)).map(i => i.toNumber())
+    sellVolume = (await dx.sellVolumesCurrent.call(gno.address, eth.address))
+    buyVolume = (await dx.buyVolumes.call(gno.address, eth.address))
+    oustandingVolume = (sellVolume.mul(bn(num2)).div(bn(den2))).sub(buyVolume)
+    logger('oustandingVolume', oustandingVolume)
+    logger('buyVolume', buyVolume)
+    assert.equal((bn(valMinusFee(totalSellAmount2ndAuction)).mul(buyVolume).div(buyVolume.add(oustandingVolume))).toNumber(), claimedAmount2)
+  })
+})
+
+contract('DutchExchange - claimBuyerFunds', (accounts) => {
+  const [, seller1, buyer1] = accounts
+  const totalSellAmount2ndAuction = 10e18
+
+  before(async () => {
+    // get contracts
+    await setupContracts()
+
+    // set up accounts and tokens[contracts]
+    await setupTest(accounts, contracts, startBal)
+
+    // add tokenPair ETH GNO
+    await dx.addTokenPair(
+      eth.address,
+      gno.address,
+      10e18,
+      0,
+      2,
+      1,
+      { from: seller1 },
+    )
+
+    eventWatcher(dx, 'Log', {})
+  })
+
+  after(eventWatcher.stopWatching)
+
+  it('5. check right amount of coins is returned by claimBuyerFunds if auction is  not closed, but closed theoretical ', async () => {
+    // prepare test by starting and clearning new auction
+  
+    const auctionIndex = await getAuctionIndex()
+    await waitUntilPriceIsXPercentOfPreviousPrice(eth, gno, 1)
+    await postBuyOrder(eth, gno, auctionIndex, 10e18, buyer1)
+  
+
+    await waitUntilPriceIsXPercentOfPreviousPrice(eth, gno, 0.4)
+
+    // checking that closingPriceToken.num == 0
+    const [closingPriceNumToken] = (await dx.closingPrices(eth.address, gno.address, auctionIndex)).map(i => i.toNumber())
+    assert.equal(closingPriceNumToken, 0)
+    
+    // actual testing
+    const [claimedAmount] = (await dx.claimBuyerFunds.call(eth.address, gno.address, buyer1, auctionIndex)).map(i => i.toNumber())
+    // first halve has been withdraw in pre
+    assert.equal(bn(valMinusFee(totalSellAmount2ndAuction)), claimedAmount)
+  })
+})
+
+
+contract('DutchExchange - claimBuyerFunds', (accounts) => {
+  const [, seller1, , buyer1] = accounts
+
+  before(async () => {
+    // get contracts
+    await setupContracts()
+
+    // set up accounts and tokens[contracts]
+    await setupTest(accounts, contracts, startBal)
+
+    // add tokenPair ETH GNO
+    await dx.addTokenPair(
+      eth.address,
+      gno.address,
+      10e18,
+      0,
+      2,
+      1,
+      { from: seller1 },
+    )
+
+    eventWatcher(dx, 'Log', {})
+  })
+
+  after(eventWatcher.stopWatching)
+
+  it('6. check that already claimedBuyerfunds are substracted properly', async () => {
+    // prepare test by starting and clearning new auction
+  
+    const auctionIndex = await getAuctionIndex()
+    await waitUntilPriceIsXPercentOfPreviousPrice(eth, gno, 1)
+    await postBuyOrder(eth, gno, auctionIndex, 10e18, buyer1)
+
+    // first withdraw  
+    const [claimedAmount] = (await dx.claimBuyerFunds.call(eth.address, gno.address, buyer1, auctionIndex)).map(i => i.toNumber())
+    await dx.claimBuyerFunds(eth.address, gno.address, buyer1, auctionIndex)
+    
+    const [num, den] = (await dx.getPriceForJS.call(eth.address, gno.address, auctionIndex))
+    logger('num', num)
+    logger('den', den)
+    assert.equal((bn(valMinusFee(10e18)).div(num).mul(den)).toNumber(), claimedAmount)
+    
+    // second withdraw
+    await waitUntilPriceIsXPercentOfPreviousPrice(eth, gno, 0.4)
+    const [claimedAmount2] = (await dx.claimBuyerFunds.call(eth.address, gno.address, buyer1, auctionIndex)).map(i => i.toNumber())
+    await dx.claimBuyerFunds(eth.address, gno.address, buyer1, auctionIndex)
+    assert.equal((bn(valMinusFee(10e18)).sub(bn(valMinusFee(10e18)).div(num).mul(den))).toNumber(), claimedAmount2)
+  })
+})

--- a/test/dutchExchange-claimBuyerFunds.js
+++ b/test/dutchExchange-claimBuyerFunds.js
@@ -6,7 +6,6 @@ TUL token issuing will not be covered in these tests, as they are covered in the
 */
 
 const bn = require('bignumber.js')
-
 const { 
   eventWatcher,
   assertRejects,

--- a/test/dutchExchange-getPrice.js
+++ b/test/dutchExchange-getPrice.js
@@ -1,0 +1,150 @@
+/* eslint no-console:0, max-len:0, no-plusplus:0, no-mixed-operators:0, no-trailing-spaces:0 */
+
+const bn = require('bignumber.js')
+
+const { 
+  eventWatcher,
+  logger,
+  timestamp,
+} = require('./utils')
+
+const {
+  setupTest,
+  getContracts,
+  getAuctionIndex,
+  checkBalanceBeforeClaim,
+  waitUntilPriceIsXPercentOfPreviousPrice,
+  setAndCheckAuctionStarted,
+  postBuyOrder,
+  calculateTokensInExchange,
+} = require('./testFunctions')
+
+// Test VARS
+let eth
+let gno
+let dx
+let oracle
+let tokenTUL
+let balanceInvariant
+const ether = 10 ** 18
+
+let contracts
+
+const valMinusFee = amount => amount - (amount / 200)
+
+const setupContracts = async () => {
+  contracts = await getContracts();
+  // destructure contracts into upper state
+  ({
+    DutchExchange: dx,
+    EtherToken: eth,
+    TokenGNO: gno,
+    TokenTUL: tokenTUL,
+    PriceOracleInterface: oracle,
+  } = contracts)
+}
+const startBal = {
+  startingETH: 90.0.toWei(),
+  startingGNO: 90.0.toWei(),
+  ethUSDPrice: 1008.0.toWei(),
+  sellingAmount: 50.0.toWei(), // Same as web3.toWei(50, 'ether')
+}
+
+
+contract('DutchExchange - getPrice', (accounts) => {
+  const [, seller1, , buyer1, buyer2] = accounts
+
+
+  before(async () => {
+    // get contracts
+    await setupContracts()
+
+    // set up accounts and tokens[contracts]
+    await setupTest(accounts, contracts, startBal)
+
+    // add tokenPair ETH GNO
+    await dx.addTokenPair(
+      eth.address,
+      gno.address,
+      10 * ether,
+      0,
+      2,
+      1,
+      { from: seller1 },
+    )
+
+    eventWatcher(dx, 'Log', {})
+  })
+
+  after(eventWatcher.stopWatching)
+
+  it('1. check that getPrice returns the right value according to time for a normal running auction', async () => {
+    const auctionIndex = await getAuctionIndex()
+    await setAndCheckAuctionStarted(eth, gno)
+    const auctionStart = (await dx.getAuctionStart(eth.address, gno.address)).toNumber
+
+    await waitUntilPriceIsXPercentOfPreviousPrice(eth, gno, 1.5)
+    let num, den 
+    [num, den] = (await dx.getPriceForJS(eth.address, gno.address, auctionIndex))
+    const currenttime = timestamp()
+    let numPrevious, denPrevious 
+    [numPrevious, denPrevious] = (await dx.computeRatioOfHistoricalPriceOracles(eth.address, gno.address, auctionIndex - 1))
+    const timeElapsed = currenttime - auctionStart 
+    assert.equal(num, bn((86400 - timeElapsed)).mul(numPrevious))
+    assert.equal(den, bn((timeElapsed + 43200)).mul(denPrevious))
+  })
+
+  it('2. check that getPrice returns the right value (closing Price ) for a theoretical closed auction', async () => {
+    await waitUntilPriceIsXPercentOfPreviousPrice(eth, gno, 1)
+    await postBuyOrder(eth, gno, 5 * 10e17, buyer1)
+    await postBuyOrder(eth, gno, 5 * 10e17, buyer2)
+    // closing theoretical
+    await waitUntilPriceIsXPercentOfPreviousPrice(eth, gno, 0.4)
+    
+    // check prices:  - actually reduantant with tests postBuyOrder
+    const closingPriceNum = (await dx.buyVolumes(eth.address, gno.address)).toNumber
+    const closingPriceDen = (await dx.sellVolumesCurrent(eth.address, gno.address)).toNumber
+
+      [num, den] = (await dx.getPriceForJS(eth.address, gno.address, auctionIndex))
+
+    assert.equal(closingPriceNum, num)
+    assert.equal(closingPriceDen, den)
+  })
+
+
+  it('3. check that getPrice returns the (0,0) for future auctions', async () => {
+    const auctionIndex = 1 
+    /* -- claim Buyerfunds - function does this:
+    * 1. balanceBeforeClaim = (await dx.balances.call(eth.address, buyer1)).toNumber()
+    * 2. await dx.claimBuyerFunds(eth.address, gno.address, buyer1, auctionIndex)
+    * 3. assert.equal(balanceBeforeClaim + 10 ** 9 - (await dx.balances.call(eth.address, buyer1)).toNumber() < MaxRoundingError, true)
+    */
+    await checkBalanceBeforeClaim(buyer1, auctionIndex, 'buyer', eth, gno, valMinusFee(10 * ether), 100000)
+
+    // claim Sellerfunds
+    await checkBalanceBeforeClaim(seller1, auctionIndex, 'seller', eth, gno, valMinusFee(10 * ether * 3), 10 ** 17)
+
+    // check prices:  - actually reduantant with tests postBuyOrder
+    const [closingPriceNum, closingPriceDen] = (await dx.closingPrices.call(eth.address, gno.address, 1))
+    await checkInvariants(balanceInvariant, accounts, [eth, gno])
+    assert.equal(closingPriceNum.minus(closingPriceDen.mul(3)).abs().toNumber() < 10 ** 17, true)
+  })
+
+  it('4. check that getPrice returns the averaged price for historical prices.', async () => {
+    const auctionIndex = 1 
+    /* -- claim Buyerfunds - function does this:
+    * 1. balanceBeforeClaim = (await dx.balances.call(eth.address, buyer1)).toNumber()
+    * 2. await dx.claimBuyerFunds(eth.address, gno.address, buyer1, auctionIndex)
+    * 3. assert.equal(balanceBeforeClaim + 10 ** 9 - (await dx.balances.call(eth.address, buyer1)).toNumber() < MaxRoundingError, true)
+    */
+    await checkBalanceBeforeClaim(buyer1, auctionIndex, 'buyer', eth, gno, valMinusFee(10 * ether), 100000)
+
+    // claim Sellerfunds
+    await checkBalanceBeforeClaim(seller1, auctionIndex, 'seller', eth, gno, valMinusFee(10 * ether * 3), 10 ** 17)
+
+    // check prices:  - actually reduantant with tests postBuyOrder
+    const [closingPriceNum, closingPriceDen] = (await dx.closingPrices.call(eth.address, gno.address, 1))
+    await checkInvariants(balanceInvariant, accounts, [eth, gno])
+    assert.equal(closingPriceNum.minus(closingPriceDen.mul(3)).abs().toNumber() < 10 ** 17, true)
+  })
+})

--- a/test/dutchExchange-getPrice.js
+++ b/test/dutchExchange-getPrice.js
@@ -12,25 +12,17 @@ const {
   setupTest,
   getContracts,
   getAuctionIndex,
-  checkBalanceBeforeClaim,
   waitUntilPriceIsXPercentOfPreviousPrice,
   setAndCheckAuctionStarted,
   postBuyOrder,
-  calculateTokensInExchange,
 } = require('./testFunctions')
 
 // Test VARS
 let eth
 let gno
 let dx
-let oracle
-let tokenTUL
-let balanceInvariant
-const ether = 10 ** 18
 
 let contracts
-
-const valMinusFee = amount => amount - (amount / 200)
 
 const setupContracts = async () => {
   contracts = await getContracts();
@@ -39,8 +31,6 @@ const setupContracts = async () => {
     DutchExchange: dx,
     EtherToken: eth,
     TokenGNO: gno,
-    TokenTUL: tokenTUL,
-    PriceOracleInterface: oracle,
   } = contracts)
 }
 const startBal = {
@@ -66,7 +56,7 @@ contract('DutchExchange - getPrice', (accounts) => {
     await dx.addTokenPair(
       eth.address,
       gno.address,
-      10 * ether,
+      10e18,
       0,
       2,
       1,
@@ -81,70 +71,53 @@ contract('DutchExchange - getPrice', (accounts) => {
   it('1. check that getPrice returns the right value according to time for a normal running auction', async () => {
     const auctionIndex = await getAuctionIndex()
     await setAndCheckAuctionStarted(eth, gno)
-    const auctionStart = (await dx.getAuctionStart(eth.address, gno.address)).toNumber
-
+    const auctionStart = (await dx.getAuctionStart(eth.address, gno.address)).toNumber()
     await waitUntilPriceIsXPercentOfPreviousPrice(eth, gno, 1.5)
-    let num, den 
-    [num, den] = (await dx.getPriceForJS(eth.address, gno.address, auctionIndex))
+
+    const [num, den] = (await dx.getPriceForJS(eth.address, gno.address, auctionIndex)).map(i => i.toNumber())
     const currenttime = timestamp()
-    let numPrevious, denPrevious 
-    [numPrevious, denPrevious] = (await dx.computeRatioOfHistoricalPriceOracles(eth.address, gno.address, auctionIndex - 1))
+    const [numPrevious, denPrevious] = (await dx.computeRatioOfHistoricalPriceOraclesForJS.call(eth.address, gno.address, auctionIndex)).map(i => i.toNumber())
     const timeElapsed = currenttime - auctionStart 
-    assert.equal(num, bn((86400 - timeElapsed)).mul(numPrevious))
-    assert.equal(den, bn((timeElapsed + 43200)).mul(denPrevious))
+    logger('numPrevious', numPrevious)
+    logger('timeE', timeElapsed)
+    assert.equal(num, bn((86400 - timeElapsed)).mul(numPrevious).toNumber())
+    assert.equal(den, bn((timeElapsed + 43200)).mul(denPrevious).toNumber())
   })
 
   it('2. check that getPrice returns the right value (closing Price ) for a theoretical closed auction', async () => {
+    const auctionIndex = await getAuctionIndex()
+
     await waitUntilPriceIsXPercentOfPreviousPrice(eth, gno, 1)
-    await postBuyOrder(eth, gno, 5 * 10e17, buyer1)
-    await postBuyOrder(eth, gno, 5 * 10e17, buyer2)
+    await postBuyOrder(eth, gno, auctionIndex, 5 * 10e17, buyer1)
+    await postBuyOrder(eth, gno, auctionIndex, 5 * 10e17, buyer2)
     // closing theoretical
     await waitUntilPriceIsXPercentOfPreviousPrice(eth, gno, 0.4)
     
     // check prices:  - actually reduantant with tests postBuyOrder
-    const closingPriceNum = (await dx.buyVolumes(eth.address, gno.address)).toNumber
-    const closingPriceDen = (await dx.sellVolumesCurrent(eth.address, gno.address)).toNumber
-
-      [num, den] = (await dx.getPriceForJS(eth.address, gno.address, auctionIndex))
-
+    const closingPriceNum = (await dx.buyVolumes(eth.address, gno.address)).toNumber()
+    const closingPriceDen = (await dx.sellVolumesCurrent(eth.address, gno.address)).toNumber()
+    const [num, den] = (await dx.getPriceForJS(eth.address, gno.address, auctionIndex))
     assert.equal(closingPriceNum, num)
     assert.equal(closingPriceDen, den)
   })
 
 
   it('3. check that getPrice returns the (0,0) for future auctions', async () => {
-    const auctionIndex = 1 
-    /* -- claim Buyerfunds - function does this:
-    * 1. balanceBeforeClaim = (await dx.balances.call(eth.address, buyer1)).toNumber()
-    * 2. await dx.claimBuyerFunds(eth.address, gno.address, buyer1, auctionIndex)
-    * 3. assert.equal(balanceBeforeClaim + 10 ** 9 - (await dx.balances.call(eth.address, buyer1)).toNumber() < MaxRoundingError, true)
-    */
-    await checkBalanceBeforeClaim(buyer1, auctionIndex, 'buyer', eth, gno, valMinusFee(10 * ether), 100000)
-
-    // claim Sellerfunds
-    await checkBalanceBeforeClaim(seller1, auctionIndex, 'seller', eth, gno, valMinusFee(10 * ether * 3), 10 ** 17)
-
-    // check prices:  - actually reduantant with tests postBuyOrder
-    const [closingPriceNum, closingPriceDen] = (await dx.closingPrices.call(eth.address, gno.address, 1))
-    await checkInvariants(balanceInvariant, accounts, [eth, gno])
-    assert.equal(closingPriceNum.minus(closingPriceDen.mul(3)).abs().toNumber() < 10 ** 17, true)
+    const auctionIndex = await getAuctionIndex()
+    const [num, den] = (await dx.getPriceForJS(eth.address, gno.address, auctionIndex + 1)).map(i => i.toNumber())
+    assert.equal(0, num)
+    assert.equal(0, den)
   })
 
-  it('4. check that getPrice returns the averaged price for historical prices.', async () => {
-    const auctionIndex = 1 
-    /* -- claim Buyerfunds - function does this:
-    * 1. balanceBeforeClaim = (await dx.balances.call(eth.address, buyer1)).toNumber()
-    * 2. await dx.claimBuyerFunds(eth.address, gno.address, buyer1, auctionIndex)
-    * 3. assert.equal(balanceBeforeClaim + 10 ** 9 - (await dx.balances.call(eth.address, buyer1)).toNumber() < MaxRoundingError, true)
-    */
-    await checkBalanceBeforeClaim(buyer1, auctionIndex, 'buyer', eth, gno, valMinusFee(10 * ether), 100000)
+  it('4. check that getPrice returns the right value (closing Price ) for a closed auction', async () => {
+    const auctionIndex = await getAuctionIndex()
 
-    // claim Sellerfunds
-    await checkBalanceBeforeClaim(seller1, auctionIndex, 'seller', eth, gno, valMinusFee(10 * ether * 3), 10 ** 17)
-
-    // check prices:  - actually reduantant with tests postBuyOrder
-    const [closingPriceNum, closingPriceDen] = (await dx.closingPrices.call(eth.address, gno.address, 1))
-    await checkInvariants(balanceInvariant, accounts, [eth, gno])
-    assert.equal(closingPriceNum.minus(closingPriceDen.mul(3)).abs().toNumber() < 10 ** 17, true)
+    await waitUntilPriceIsXPercentOfPreviousPrice(eth, gno, 1)
+    // clearning the auction
+    await postBuyOrder(eth, gno, auctionIndex, 50 * 10e17, buyer2)
+    const [closingPriceNum, closingPriceDen] = (await dx.closingPrices(eth.address, gno.address, auctionIndex)).map(i => i.toNumber())
+    const [num, den] = (await dx.getPriceForJS(eth.address, gno.address, auctionIndex)).map(i => i.toNumber())
+    assert.equal(closingPriceNum, num)
+    assert.equal(closingPriceDen, den)
   })
 })

--- a/test/dutchExchange-historicalPriceOracle.js
+++ b/test/dutchExchange-historicalPriceOracle.js
@@ -1,0 +1,153 @@
+/* eslint no-console:0, max-len:0, no-plusplus:0, no-mixed-operators:0, no-trailing-spaces:0 */
+
+const bn = require('bignumber.js')
+
+const { 
+  eventWatcher,
+} = require('./utils')
+
+const {
+  setupTest,
+  getContracts,
+  getAuctionIndex,
+  waitUntilPriceIsXPercentOfPreviousPrice,
+  setAndCheckAuctionStarted,
+  postBuyOrder,
+  postSellOrder,
+} = require('./testFunctions')
+
+// Test VARS
+let eth
+let gno
+let dx
+
+let contracts
+
+const setupContracts = async () => {
+  contracts = await getContracts();
+  // destructure contracts into upper state
+  ({
+    DutchExchange: dx,
+    EtherToken: eth,
+    TokenGNO: gno,
+  } = contracts)
+}
+const startBal = {
+  startingETH: 90.0.toWei(),
+  startingGNO: 90.0.toWei(),
+  ethUSDPrice: 1008.0.toWei(),
+  sellingAmount: 50.0.toWei(), // Same as web3.toWei(50, 'ether')
+}
+
+
+contract('DutchExchange - historicalPriceOracleForJS', (accounts) => {
+  const [, seller1, seller2, buyer1] = accounts
+
+
+  before(async () => {
+    // get contracts
+    await setupContracts()
+
+    // set up accounts and tokens[contracts]
+    await setupTest(accounts, contracts, startBal)
+
+    // add tokenPair ETH GNO
+    await dx.addTokenPair(
+      eth.address,
+      gno.address,
+      10e18,
+      0,
+      2,
+      1,
+      { from: seller1 },
+    )
+
+    eventWatcher(dx, 'Log', {})
+  })
+
+  after(eventWatcher.stopWatching)
+
+  it('1. check that price for ETH is (1,1)', async () => {
+    const auctionIndex = await getAuctionIndex()
+    await setAndCheckAuctionStarted(eth, gno)
+    await waitUntilPriceIsXPercentOfPreviousPrice(eth, gno, 1.5)
+    const [num, den] = (await dx.historicalPriceOracleForJS(eth.address, auctionIndex)).map(i => i.toNumber())
+
+    assert.equal(num, 1)
+    assert.equal(den, 1)
+  })
+
+  it(' 2. check that price is correct for closingPriceToken.num == 0', async () => {
+    let auctionIndex = await getAuctionIndex()
+
+    await waitUntilPriceIsXPercentOfPreviousPrice(eth, gno, 1)
+    
+    // closing auction
+    await waitUntilPriceIsXPercentOfPreviousPrice(eth, gno, 1)
+    await postBuyOrder(eth, gno, auctionIndex, 2 * 10e18, buyer1)
+
+    // check that auction acutally closed
+    auctionIndex = await getAuctionIndex()
+    assert.equal(2, auctionIndex)
+
+    // checking that closingPriceToken.num == 0
+    const [closingPriceNumToken] = (await dx.closingPrices(gno.address, eth.address, auctionIndex - 1)).map(i => i.toNumber())
+    assert.equal(closingPriceNumToken, 0)
+
+    // actual testing
+    const [closingPriceNum, closingPriceDen] = (await dx.closingPrices(eth.address, gno.address, auctionIndex - 1)).map(i => i.toNumber())
+    const [num, den] = (await dx.historicalPriceOracleForJS(gno.address, auctionIndex)).map(i => i.toNumber())
+    // We need to check the inverse closingPrices, since we have eth, gno prices
+    assert.equal(closingPriceDen, num)
+    assert.equal(closingPriceNum, den)
+  })
+
+
+  it('3. check that price is correct for closingPriceToken.num == 0', async () => {
+    let auctionIndex = await getAuctionIndex()
+
+    // prepare test by starting and clearning new auction
+    await postSellOrder(gno, eth, 0, 10e18, seller2)
+    await waitUntilPriceIsXPercentOfPreviousPrice(eth, gno, 1)
+    await postBuyOrder(gno, eth, auctionIndex, 2 * 10e18, buyer1)
+    
+    // check that auction acutally closed
+    auctionIndex = await getAuctionIndex()
+    assert.equal(3, auctionIndex)
+
+    // checking that closingPriceToken.num == 0
+    const [closingPriceNumToken] = (await dx.closingPrices(eth.address, gno.address, auctionIndex - 1)).map(i => i.toNumber())
+    assert.equal(closingPriceNumToken, 0)
+    
+    // actual testing
+    const [closingPriceNum, closingPriceDen] = (await dx.closingPrices(gno.address, eth.address, auctionIndex - 1)).map(i => i.toNumber())
+    const [num, den] = (await dx.historicalPriceOracleForJS(gno.address, auctionIndex)).map(i => i.toNumber())
+    assert.equal(closingPriceNum, num)
+    assert.equal(closingPriceDen, den)
+  })
+
+  it('4. check that price returns the averaged price by volume, if both previous volumes >0 ', async () => {
+    let auctionIndex = await getAuctionIndex()
+    // start new auctions
+    await postSellOrder(gno, eth, 0, 10e17, seller2)
+    await postSellOrder(eth, gno, 0, 10e18, seller2)
+    
+    // clear new auctions
+    await waitUntilPriceIsXPercentOfPreviousPrice(eth, gno, 1)
+    await postBuyOrder(gno, eth, auctionIndex, 2 * 10e18, buyer1)
+    await postBuyOrder(eth, gno, auctionIndex, 2 * 10e18, buyer1)
+
+    // check that auction acutally closed
+    auctionIndex = await getAuctionIndex()
+    assert.equal(4, auctionIndex)
+
+    const [closingPriceNum, closingPriceDen] = (await dx.closingPrices(eth.address, gno.address, auctionIndex)).map(i => i.toNumber())
+    const [closingPriceNumOpp, closingPriceDenOpp] = (await dx.closingPrices(gno.address, eth.address, auctionIndex)).map(i => i.toNumber())
+    const [num, den] = (await dx.getPriceForJS(eth.address, gno.address, auctionIndex)).map(i => i.toNumber())
+    // closingPriceETH.den ** 2 * closingPriceToken.den + closingPriceToken.num ** 2 * closingPriceETH.num;
+    // closingPriceETH.num * closingPriceToken.den * (closingPriceETH.den + closingPriceToken.num);
+    assert.equal(bn(closingPriceDen).mul(bn(closingPriceDen)).mul(bn(closingPriceDenOpp)).add(bn(closingPriceNumOpp).mul(bn(closingPriceNumOpp)).mul(bn(closingPriceNum))), num)
+    assert.equal(bn(closingPriceNum).mul(closingPriceDenOpp).mul(bn(closingPriceDen).add(closingPriceNumOpp)), den)
+  })
+})
+


### PR DESCRIPTION
just review pull request and unfortunately all the tests form priceOracle and historicalPriceOracle are also attacked. Sry. Will clear that later.
---
tests the claimBuyerFunds function

-- tulip generation is not tests, since this is covered in the other tests