### PR TITLE
Feature/dx 269 menu wallet fee ratio no wallet

### DIFF
--- a/src/components/Loader/index.tsx
+++ b/src/components/Loader/index.tsx
@@ -3,18 +3,20 @@ import React, { ReactElement } from 'react'
 interface LoaderProps {
   reSize?: number;
   hasData: any;
+  svgHeight?: number;
   message?: string;
   render(): ReactElement<any>;
 }
 
 class Loader extends React.Component<LoaderProps> {
   static defaultProps = {
+    svgHeight: 50,
     reSize: 1,
   }
 
   renderSVG = () =>
     <div className="svgContainer" style={{ width: `${420 * this.props.reSize}px`, height: `${475 * this.props.reSize}px` }}>
-      <svg width="100%" height="100%" viewBox="0 0 105 20.5" version="1.1">
+      <svg width="100%" height={`${this.props.svgHeight}%`} viewBox="0 0 105 20.5" version="1.1">
         <defs>
           <polygon id="path-1" points="0.0804697719 0.0481072691 18.8121496 0.0481072691 18.8121496 19.3882033 0.0804697719 19.3882033"></polygon>
           <polygon id="path-3" points="0 0.166758882 7.75290678 0.166758882 7.75290678 14.1836979 0 14.1836979"></polygon>
@@ -45,7 +47,7 @@ class Loader extends React.Component<LoaderProps> {
           </g>
         </g>
       </svg>
-      {!!(this.props.message) && <p>{this.props.message}</p>}
+      {!!(this.props.message) && <p style={{ margin: 0 }}>{this.props.message}</p>}
     </div>
 
   render() {

--- a/src/components/MenuFeeBalance/index.tsx
+++ b/src/components/MenuFeeBalance/index.tsx
@@ -7,17 +7,14 @@ import { Balance } from 'types'
 
 export interface MenuFeeBalanceProps {
   feeRatio: number,
-  mgnSupply: Balance
+  mgnSupply: Balance,
+  noWallet: boolean,
 }
 
-const MenuFeeBalance = ({ feeRatio, mgnSupply }: MenuFeeBalanceProps) =>
-  mgnSupply && feeRatio
-    ?
-    <div className="menuFeeBalance">
-      <p>MGN <strong>{mgnSupply}</strong></p>
-      <p>Fee level <strong>{`${feeRatio * 100}%`}</strong></p>
-    </div>
-    :
-    <div className="menuFeeBalance"><p>Loading Fee Info ... </p></div>
+const MenuFeeBalance = ({ feeRatio, mgnSupply, noWallet }: MenuFeeBalanceProps) =>
+  <div className="menuFeeBalance">
+    <p>MGN <strong>{!noWallet && mgnSupply && feeRatio ? mgnSupply : 0}</strong></p>
+    <p>Fee level <strong>{`${!noWallet && mgnSupply && feeRatio ? feeRatio * 100 : 0.5}%`}</strong></p>
+  </div>
 
 export default MenuFeeBalance

--- a/src/components/MenuWallet/index.tsx
+++ b/src/components/MenuWallet/index.tsx
@@ -21,13 +21,15 @@ export interface WalletProps {
 export const MenuWallet: React.SFC<WalletProps> = ({ account, addressToSymbolDecimal, balance, tokens }) => (
   <div className="menuWallet">
     <span>
-      <code>{`${account ? account.slice(0,10) : 'loading...'}...`}</code>
-      <small>{balance != null ? balance.toNumber().toFixed(4) : 'loading...'} ETH</small>
+      <code>{`${account ? account.slice(0,10) : 'No Wallet Detected'}...`}</code>
+      <small>{balance != null ? balance.toNumber().toFixed(4) : '0'} ETH</small>
     </span>
-    <div>
+    {account && <div>
       <Loader
       hasData={Object.keys(addressToSymbolDecimal).length > 0}
-      reSize={0.2}
+      message="Enable wallet"
+      svgHeight={35}
+      reSize={0.25}
       render={() =>
         <table>
           <thead>
@@ -50,7 +52,7 @@ export const MenuWallet: React.SFC<WalletProps> = ({ account, addressToSymbolDec
           </tbody>
         </table>
       }/>
-    </div>
+    </div>}
   </div>
 )
 

--- a/src/containers/MenuFeeBalance/index.ts
+++ b/src/containers/MenuFeeBalance/index.ts
@@ -4,9 +4,10 @@ import MenuFeeBalance from 'components/MenuFeeBalance'
 
 import { State } from 'types'
 
-const mapState = ({ blockchain: { feeRatio, mgnSupply } }: State) => ({
+const mapState = ({ blockchain: { currentAccount, feeRatio, mgnSupply } }: State) => ({
   feeRatio,
   mgnSupply,
+  noWallet: !currentAccount,
 })
 
 export default connect(mapState)(MenuFeeBalance)


### PR DESCRIPTION
Conditionally renders Header components / changes wording if wallet not connected

Opted to leave out drop down table entirely if no `account` detected in `MenuWallet`

Small Issue: `MenuWallet` component uses `CSS` `::after` rule to create `dropdown triangle` element - which is not entirely conditionally renderable ... Not a huge issue.