### PR TITLE
Fix/dx 268 no sell amount more than sell balance

### DIFF
--- a/src/components/AuctionSellingGetting/index.tsx
+++ b/src/components/AuctionSellingGetting/index.tsx
@@ -4,7 +4,7 @@ import { Balance } from 'types'
 
 /* CONSIDER ADDING GAS_COST */
 export interface AuctionSellingGettingProps {
-  sellTokenBalance: Balance,
+  maxSellAmount: string,
   buyTokenSymbol: string,
   sellTokenSymbol: string,
   sellAmount: Balance,
@@ -19,15 +19,15 @@ class AuctionSellingGetting extends Component<AuctionSellingGettingProps> {
   }
 
   onClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
-    const { sellTokenBalance, setSellTokenAmount } = this.props
+    const { maxSellAmount, setSellTokenAmount } = this.props
 
     e.preventDefault()
 
-    setSellTokenAmount({ sellAmount: sellTokenBalance })
+    setSellTokenAmount({ sellAmount: maxSellAmount })
   }
 
   render() {
-    const { sellTokenSymbol, buyTokenSymbol, buyAmount, sellTokenBalance, sellAmount } = this.props
+    const { sellTokenSymbol, buyTokenSymbol, buyAmount, maxSellAmount, sellAmount } = this.props
 
     return (
       <div className="auctionAmounts">
@@ -40,7 +40,7 @@ class AuctionSellingGetting extends Component<AuctionSellingGettingProps> {
           onChange={this.onChange}
           value={sellAmount}
           min="0"
-          max={sellTokenBalance}
+          max={maxSellAmount}
         />
         <small>{sellTokenSymbol}</small>
 

--- a/src/components/AuctionSellingGetting/index.tsx
+++ b/src/components/AuctionSellingGetting/index.tsx
@@ -14,8 +14,18 @@ export interface AuctionSellingGettingProps {
 
 
 class AuctionSellingGetting extends Component<AuctionSellingGettingProps> {
-  onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    this.props.setSellTokenAmount({ sellAmount: e.target.value })
+  onChange = (e: React.ChangeEvent<HTMLInputElement & HTMLFormElement>) => {
+    const input = e.target
+    const { value } = input
+    const { setSellTokenAmount, maxSellAmount } = this.props
+    setSellTokenAmount({ sellAmount: value })
+
+    if (+value > +maxSellAmount) {
+      input.setCustomValidity(`amount available for sale is ${maxSellAmount}`)
+      input.reportValidity()
+    } else {
+      input.setCustomValidity('')
+    }
   }
 
   onClick = (e: React.MouseEvent<HTMLAnchorElement>) => {

--- a/src/components/OrderPanel/index.tsx
+++ b/src/components/OrderPanel/index.tsx
@@ -8,15 +8,13 @@ import ButtonCTA from 'components/ButtonCTA'
 import TokenPair from 'containers/TokenPair'
 import TokenOverlay from 'containers/TokenOverlay'
 
-import { Balance } from 'types'
-
 interface OrderPanelProps {
   sellTokenSymbol: string,
   buyTokenSymbol: string,
-  sellAmount: Balance
+  validSellAmount: boolean,
 }
 
-const OrderPanel: React.SFC<OrderPanelProps> = ({ sellTokenSymbol, buyTokenSymbol, sellAmount }) => (
+const OrderPanel: React.SFC<OrderPanelProps> = ({ sellTokenSymbol, buyTokenSymbol, validSellAmount }) => (
   <AuctionContainer auctionDataScreen="amount">
     <TokenOverlay />
     <AuctionHeader backTo="/">
@@ -32,10 +30,10 @@ const OrderPanel: React.SFC<OrderPanelProps> = ({ sellTokenSymbol, buyTokenSymbo
     <AuctionSellingGetting />
     {/* TODO: replace onclick with some logic (maybe: "to" prop) */}
     <ButtonCTA
-      className={+sellAmount > 0 ? 'blue' : 'buttonCTA-disabled'}
-      onClick={e => +sellAmount > 0 ? console.log('Continuing to wallet') : e.preventDefault()}
+      className={validSellAmount ? 'blue' : 'buttonCTA-disabled'}
+      onClick={e => validSellAmount ? console.log('Continuing to wallet') : e.preventDefault()}
       to={'./wallet'}>
-      {+sellAmount > 0 ? 'Continue to wallet details' : 'Please select a sell amount'}
+      {validSellAmount ? 'Continue to wallet details' : 'Please select a sell amount'}
     </ButtonCTA>
   </AuctionContainer>
 )

--- a/src/containers/AuctionSellingGetting/index.ts
+++ b/src/containers/AuctionSellingGetting/index.ts
@@ -10,10 +10,11 @@ const mapState = (state: State) => {
   const { sell, buy, price } = findRatioPair(state) || Object.assign({ price: 2 }, state.tokenPair)
   const { [sell.address]: sellTokenBalance } = state.tokenBalances
   const { sellAmount } = state.tokenPair
+  const maxSellAmount = sellTokenBalance.div(10 ** sell.decimals).toFixed(0)
 
   return ({
     // TODO: change prop to sellTokenBalance
-    sellTokenBalance,
+    maxSellAmount,
     sellTokenSymbol: sell.symbol || sell.name || sell.address,
     buyTokenSymbol: buy.symbol || buy.name || buy.address,
     sellAmount,

--- a/src/containers/OrderPanel/index.ts
+++ b/src/containers/OrderPanel/index.ts
@@ -1,12 +1,19 @@
 import { connect } from 'react-redux'
 import OrderPanel from 'components/OrderPanel'
-import { State } from 'types'
+import { State, BigNumber } from 'types'
 
-const mapStateToProps = ({ tokenPair: { sell, buy, sellAmount } }: State) => ({
-  sellTokenSymbol: sell.symbol || sell.name || sell.address,
-  buyTokenSymbol: buy.symbol || buy.name || buy.address,
-  sellAmount,
-})
+const mapStateToProps = (state: State) => {
+  const { tokenPair: { sell, buy, sellAmount } } = state
+  const { [sell.address]: sellTokenBalance } = state.tokenBalances
+  // const { sellAmount } = state.tokenPair
+  const maxSellAmount: BigNumber = sellTokenBalance.div(10 ** sell.decimals)
+
+  return {
+    sellTokenSymbol: sell.symbol || sell.name || sell.address,
+    buyTokenSymbol: buy.symbol || buy.name || buy.address,
+    validSellAmount: +sellAmount > 0 && maxSellAmount.greaterThanOrEqualTo(sellAmount),
+  }
+}
 
 
 export default connect(mapStateToProps)(OrderPanel)

--- a/stories/AuctionContainer.tsx
+++ b/stories/AuctionContainer.tsx
@@ -39,7 +39,7 @@ storiesOf('AuctionContainer', module)
       <TokenPair />
       <AuctionPriceBar header="Closing Price" />
       <AuctionSellingGetting
-        sellTokenBalance={number('balance', 0, {
+        maxSellAmount={number('balance', 0, {
           range: true,
           min: 0,
           max: 5000,

--- a/stories/AuctionSellingGetting.tsx
+++ b/stories/AuctionSellingGetting.tsx
@@ -27,7 +27,7 @@ storiesOf('Auction Sell & Get', module)
 
     return (
       <AuctionSellingGetting
-        sellTokenBalance={text('balance', '20')}
+        maxSellAmount={text('balance', '20')}
         buyTokenSymbol={object('buyTokenSymbol', 'GNO')}
         sellTokenSymbol={object('sellTokenSymbol', 'ETH')}
         sellAmount={sellAmount}


### PR DESCRIPTION
Doesn't allow to proceed to `WalletPanel` when `sellAmount> sellTokenBalance`
Also displays native message `amount available for sale is ${maxSellAmount}` at input