### PR TITLE
EXTENSION: Feature/dx 256 ongoing auction claiming and linking

### DIFF
--- a/src/actions/blockchain.ts
+++ b/src/actions/blockchain.ts
@@ -359,8 +359,11 @@ export const claimSellerFundsFromSeveral = (
         body: `Claiming ${buyName} tokens from ${sellName}-${buyName} auction. Please check ${activeProvider}`,
       },
     }))
-    const claimReceipt = await getUnclaimedSellerFundsFromSeveral(sell, buy, currentAccount, indices)
-    console.log('​claimReceipt => ', claimReceipt)
+    const [claimReceipt] = await Promise.all([
+      getUnclaimedSellerFundsFromSeveral(sell, buy, currentAccount, indices),
+      updateMainAppState(),
+    ])
+    console.log('​Claim receipt => ', claimReceipt)
     return dispatch(closeModal())
   } catch (error) {
     console.error(error.message)

--- a/src/actions/blockchain.ts
+++ b/src/actions/blockchain.ts
@@ -384,7 +384,7 @@ async function checkTokenAllowance(
   return tokenAllowance
 }
 
-function errorHandling(error: Error) {
+export function errorHandling(error: Error) {
   const errorFind = (string: string, toFind = '}', offset = 1) => {
     const place = string.search(toFind)
     return string.slice(place + offset)

--- a/src/actions/blockchain.ts
+++ b/src/actions/blockchain.ts
@@ -18,7 +18,7 @@ import {
   getETHBalance,
   getTokenBalance,
   toNative,
-  getUnclaimedSellerFundsFromSeveral,
+  claimSellerFundsFromSeveralAuctions,
 } from 'api'
 
 import {
@@ -346,7 +346,7 @@ export const approveAndPostSellOrder = (choice: string) => async (dispatch: Func
 export const claimSellerFundsFromSeveral = (
   sell: DefaultTokenObject,
   buy: DefaultTokenObject,
-  indices?: number,
+  lastNIndex?: number,
 ) => async (dispatch: Dispatch<any>, getState: () => State) => {
   const { blockchain: { activeProvider, currentAccount } } = getState(),
     sellName = sell.symbol.toUpperCase() || sell.name.toUpperCase() || sell.address,
@@ -360,7 +360,7 @@ export const claimSellerFundsFromSeveral = (
       },
     }))
     const [claimReceipt] = await Promise.all([
-      getUnclaimedSellerFundsFromSeveral(sell, buy, currentAccount, indices),
+      claimSellerFundsFromSeveralAuctions(sell, buy, currentAccount, lastNIndex),
       updateMainAppState(),
     ])
     console.log('​Claim receipt => ', claimReceipt)

--- a/src/api/dutchx.ts
+++ b/src/api/dutchx.ts
@@ -157,8 +157,7 @@ async function init(): Promise<DutchExchange> {
   ) => dx.getSellerBalancesOfCurrentAuctions.call(sellTokenArr, buyTokenArr, userAccount)
 
   const getIndicesWithClaimableTokensForSellers = (
-    sellToken: Account,
-    buyToken: Account,
+    { sell: { address: sellToken }, buy: { address: buyToken } }: TokenPair,
     userAccount: Account,
     lastNAuctions: number = 0,
   ) => dx.getIndicesWithClaimableTokensForSellers.call(sellToken, buyToken, userAccount, lastNAuctions)

--- a/src/api/dutchx.ts
+++ b/src/api/dutchx.ts
@@ -51,7 +51,7 @@ async function init(): Promise<DutchExchange> {
   const getClaimedAmounts = (
     { sell: { address: t1 }, buy: { address: t2 } }: TokenPair,
     index: Index,
-    userAccount: Account
+    userAccount: Account,
   ) => dx.claimedAmounts.call(t1, t2, index, userAccount)
 
   const postSellOrder = (
@@ -92,19 +92,32 @@ async function init(): Promise<DutchExchange> {
     { sell: { address: t1 }, buy: { address: t2 } }: TokenPair,
     index: Index,
     userAccount: Account,
-    ) => dx.claimSellerFunds.call(t1, t2, userAccount, index)
-
-  claimSellerFunds.call = (
-    { sell: { address: t1 }, buy: { address: t2 } }: TokenPair,
-    index: Index,
-    userAccount: Account,
   ) => dx.claimSellerFunds.call(t1, t2, userAccount, index)
+
+  const claimTokensFromSeveralAuctionsAsSeller = (
+    sellTokenAddresses: Account[],
+    buyTokenAddresses: Account[],
+    indices: number[],
+    account: Account,
+  ) => dx.claimTokensFromSeveralAuctionsAsSeller(
+    sellTokenAddresses,
+    buyTokenAddresses,
+    indices,
+    account,
+    { from: account },
+  )
 
   const claimBuyerFunds = (
     { sell: { address: t1 }, buy: { address: t2 } }: TokenPair,
     index: Index,
     userAccount: Account,
   ) => dx.claimBuyerFunds(t1, t2, userAccount, index, { from: userAccount })
+
+  claimBuyerFunds.call = (
+    { sell: { address: t1 }, buy: { address: t2 } }: TokenPair,
+    index: Index,
+    userAccount: Account,
+  ) => dx.claimBuyerFunds.call(t1, t2, userAccount, index)
 
   const deposit = (tokenAddress: Account, amount: Balance, userAccount: Account) =>
     dx.deposit(tokenAddress, amount, { from: userAccount })
@@ -187,6 +200,7 @@ async function init(): Promise<DutchExchange> {
     getSellerBalancesOfCurrentAuctions,
     getIndicesWithClaimableTokensForSellers,
     getClaimedAmounts,
+    claimTokensFromSeveralAuctionsAsSeller,
     getFeeRatio,
     postSellOrder,
     postBuyOrder,

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -566,7 +566,6 @@ export const getSellerOngoingAuctions = async (
 
       const { sell: { decimals }, buy: { decimals: decimalsInverse } } = auction
       if (!(indices.length >= 1 || indicesInverse.length >= 1)) {
-
         return accum
       } else {
         const { lastIndex, closingPriceDir, closingPriceOpp } = lastAuctionsData[index]

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -365,6 +365,7 @@ export interface DXAuction {
     buyTokens: Account[],
     auctionIndices: number[],
     user: Account,
+    tx: TransactionObject,
   ): Promise<Receipt>,
   claimTokensFromSeveralAuctionsAsBuyer(
     sellTokens: Account[],
@@ -403,6 +404,12 @@ export interface DutchExchange {
     account: Account,
     lastNAuctions: number,
   ): Promise<[BigNumber[], BigNumber[]]>,
+  claimTokensFromSeveralAuctionsAsSeller(
+    sellTokenAddresses: Account[],
+    buyTokenAddresses: Account[],
+    indices: number[],
+    account: Account,
+  ): Promise<Receipt>,
   getFeeRatio(account: Account): Promise<[BigNumber, BigNumber]>,
 
   postSellOrder(

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -399,8 +399,7 @@ export interface DutchExchange {
     account: Account,
   ): Promise<number[]>,
   getIndicesWithClaimableTokensForSellers(
-    sellToken: Account,
-    buyToken: Account,
+    pair: TokenPair,
     account: Account,
     lastNAuctions: number,
   ): Promise<[BigNumber[], BigNumber[]]>,

--- a/src/components/AuctionStateHOC/index.tsx
+++ b/src/components/AuctionStateHOC/index.tsx
@@ -188,9 +188,9 @@ export default (Component: React.ClassType<any, any, any>): React.ClassType<any,
       const { error } = this.state
       return (
         <div>
-          <pre style={{ position: 'fixed', zIndex: 2, opacity: 0.9 }}>
+          {/* <pre style={{ position: 'fixed', zIndex: 2, opacity: 0.9 }}>
             {JSON.stringify(this.state, null, 2)}
-          </pre>
+          </pre> */}
           <Component {...this.props} {...this.state}/> :
           {error && <h3> Invalid auction: {error}</h3>}
         </div>

--- a/src/components/MenuAuctions/index.tsx
+++ b/src/components/MenuAuctions/index.tsx
@@ -1,14 +1,18 @@
 import * as React from 'react'
 import { OngoingAuctions } from 'types'
+import { Link } from 'react-router-dom'
+import { DefaultTokenObject } from 'api/types'
 
 export interface MenuAuctionProps {
-  name?: string,
-  ongoingAuctions: OngoingAuctions
+  name?: string;
+  ongoingAuctions: OngoingAuctions;
+  claimSellerFundsFromSeveral(sell: Partial<DefaultTokenObject>, buy: Partial<DefaultTokenObject>, indices?: number): any;
 }
 
 export const MenuAuctions: React.SFC<MenuAuctionProps> = ({
   name = 'YOUR AUCTIONS',
   ongoingAuctions,
+  claimSellerFundsFromSeveral,
 }) => (
     <div className="menuAuctions"><img src={require('assets/auction.svg')} />
       {name}
@@ -26,13 +30,17 @@ export const MenuAuctions: React.SFC<MenuAuctionProps> = ({
               {ongoingAuctions.map(
                 (auction, i) =>
                   <tr key={`${auction.sell.address}-${auction.buy.address}-${i}`}>
-                    <td>{`${auction.sell.symbol}/${auction.buy.symbol}`}</td>
+                    <td>
+                      <Link to={`/auction/${auction.sell.symbol}-${auction.buy.symbol}-${auction.indices[auction.indices.length - 1]}`}>
+                        {`${auction.sell.symbol}/${auction.buy.symbol}`}
+                      </ Link>
+                    </td>
                     {/* <td>{`${auction.indices[auction.indices.length - 1]}`}</td> */}
                     <td>
                       <p>{`${auction.balancePerIndex[auction.balancePerIndex.length - 1] || 'N/A'} ${auction.sell.symbol}`}</p>
                       <p>{`${auction.balancePerIndexInverse[auction.balancePerIndexInverse.length - 1] || 0} ${auction.buy.symbol}`}</p>
                     </td>
-                    {auction.claim && <td><img src={require('assets/claim.svg')} /></td>}
+                    {auction.claim && <td onClick={() => claimSellerFundsFromSeveral(auction.sell, auction.buy)}><img src={require('assets/claim.svg')} /></td>}
                   </tr>,
               )}
             </tbody>

--- a/src/components/MenuAuctions/index.tsx
+++ b/src/components/MenuAuctions/index.tsx
@@ -6,7 +6,7 @@ import { DefaultTokenObject } from 'api/types'
 export interface MenuAuctionProps {
   name?: string;
   ongoingAuctions: OngoingAuctions;
-  claimSellerFundsFromSeveral(sell: Partial<DefaultTokenObject>, buy: Partial<DefaultTokenObject>, indices?: number): any;
+  claimSellerFundsFromSeveral(sell: Partial<DefaultTokenObject>, buy: Partial<DefaultTokenObject>, indicesWithSellerBalance?: number): any;
 }
 
 export const MenuAuctions: React.SFC<MenuAuctionProps> = ({
@@ -31,11 +31,11 @@ export const MenuAuctions: React.SFC<MenuAuctionProps> = ({
                 (auction, i) =>
                   <tr key={`${auction.sell.address}-${auction.buy.address}-${i}`}>
                     <td>
-                      <Link to={`/auction/${auction.sell.symbol}-${auction.buy.symbol}-${auction.indices[auction.indices.length - 1]}`}>
+                      <Link to={`/auction/${auction.sell.symbol}-${auction.buy.symbol}-${auction.indicesWithSellerBalance[auction.indicesWithSellerBalance.length - 1]}`}>
                         {`${auction.sell.symbol}/${auction.buy.symbol}`}
                       </ Link>
                     </td>
-                    {/* <td>{`${auction.indices[auction.indices.length - 1]}`}</td> */}
+                    {/* <td>{`${auction.indicesWithSellerBalance[auction.indicesWithSellerBalance.length - 1]}`}</td> */}
                     <td>
                       <p>{`${auction.balancePerIndex[auction.balancePerIndex.length - 1] || 'N/A'} ${auction.sell.symbol}`}</p>
                       <p>{`${auction.balancePerIndexInverse[auction.balancePerIndexInverse.length - 1] || 0} ${auction.buy.symbol}`}</p>

--- a/src/containers/MenuAuctions/index.ts
+++ b/src/containers/MenuAuctions/index.ts
@@ -3,9 +3,10 @@ import { connect } from 'react-redux'
 import { State } from 'types'
 
 import MenuAuctions from 'components/MenuAuctions'
+import { claimSellerFundsFromSeveral } from 'actions'
 
 const mapStateToProps = (state: State) => ({
   ongoingAuctions: state.auctions.ongoingAuctions,
 })
 
-export default connect(mapStateToProps)(MenuAuctions)
+export default connect(mapStateToProps, { claimSellerFundsFromSeveral })(MenuAuctions)

--- a/src/integrations/initialize.ts
+++ b/src/integrations/initialize.ts
@@ -8,7 +8,7 @@ import MetamaskProvider from './metamask'
 import ParityProvider from './parity'
 import RemoteProvider from './remote'
 
-const WATCHER_INTERVAL = 2000
+const WATCHER_INTERVAL = 6000
 
 const networkById = {
   1: ETHEREUM_NETWORKS.MAIN,

--- a/src/integrations/initialize.ts
+++ b/src/integrations/initialize.ts
@@ -8,7 +8,7 @@ import MetamaskProvider from './metamask'
 import ParityProvider from './parity'
 import RemoteProvider from './remote'
 
-const WATCHER_INTERVAL = 10000
+const WATCHER_INTERVAL = 2000
 
 const networkById = {
   1: ETHEREUM_NETWORKS.MAIN,

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -88,10 +88,10 @@ export type AuctionObject = {
     address: Account,
   },
   claim?: boolean,
-  indices?: string[] | BigNumber[],
+  indicesWithSellerBalance?: string[] | BigNumber[],
   balancePerIndex?: string[] | BigNumber[],
   claimInverse?: boolean,
-  indicesInverse?: string[] | BigNumber[],
+  indicesWithSellerBalanceInverse?: string[] | BigNumber[],
   balancePerIndexInverse?: string[] | BigNumber[],
 }
 

--- a/stories/MenuAuction.tsx
+++ b/stories/MenuAuction.tsx
@@ -20,6 +20,7 @@ const constructKnobs = (
 ) => ({
   name: text('title', name),
   ongoingAuctions: auctionsArr.map((item: object, i: number) => object(`Ongoing Auctions ${i}`, item)),
+  claimSellerFundsFromSeveral: () => console.log('Claiming!')
 })
 
 storiesOf(`MenuAuctions`, module)


### PR DESCRIPTION
# Extends #240 

1. Added `Link` component to move user to `AuctionStatus` page related to `ongoingAuction` clicked
2. Created `claimSellerFundsFromSeveral` thunk/ `api/index` and `api/dutchx` to enable claiming from auctions with sellerbalances and clear status
3. removed state print in `AuctionStatusHOC`