### PR TITLE
Hotfix/token decimals menu wallet

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -98,7 +98,8 @@ export const getTokenDecimals = async (tokenAddress: Account) => {
   const { Tokens } = await promisedAPI
 
   try {
-    await Tokens.getTokenDecimals(tokenAddress)
+    const decimals = (await Tokens.getTokenDecimals(tokenAddress)).toNumber() || 18
+    return decimals
   } catch (e) {
     console.warn(`Token @ address ${tokenAddress} has no Decimals value set - defaulting to 18`)
     return 18

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -40,7 +40,7 @@ export interface TransactionObject {
 }
 
 export interface TokensInterface {
-  getTokenDecimals(tokenAddress: Account): Promise<number>,
+  getTokenDecimals(tokenAddress: Account): Promise<BigNumber>,
   getTokenBalance(tokenAddress: Account, account: Account): Promise<BigNumber>,
   getTotalSupply(tokenAddress: Account): Promise<BigNumber>,
   transfer(tokenAddress: Account, to: Account, value: Balance, tx: TransactionObject): Promise<Receipt>,

--- a/src/components/MenuWallet/index.tsx
+++ b/src/components/MenuWallet/index.tsx
@@ -41,9 +41,10 @@ export const MenuWallet: React.SFC<WalletProps> = ({ account, addressToSymbolDec
               if (!addressToSymbolDecimal[addressKey]) return null
               const { name, decimals } = addressToSymbolDecimal[addressKey]
               return (
+                tokens[addressKey].gt(0) &&
                 <tr key={addressKey}>
                   <td>{name || 'Unknown'}</td>
-                  <td>{(tokens[addressKey]).div(10 ** decimals).toFixed(4)}</td>
+                  <td>{(tokens[addressKey]).div(10 ** decimals).toFixed(2)}</td>
                 </tr>
               )
             })}


### PR DESCRIPTION
# hotfix + feature hybrid ... aka ... HOT FEATURE

1. fixes `getDecimals` where a zero `BigNumber` return value was causing `NaN` division in `MenuWallet` - now converts `toNumber` and `||`s to `18` decimals if `0`
2. Don't show tokens that have a balance `!>0`