### PR TITLE
Fix/show upcoming auction commited balance

### DIFF
--- a/package.json
+++ b/package.json
@@ -192,7 +192,7 @@
     "minimist": "^1.2.0",
     "mocha": "^4.0.1",
     "name-all-modules-plugin": "^1.0.1",
-    "node-sass": "^4.7.2",
+    "node-sass": "^4.9.0",
     "postcss-loader": "^2.1.0",
     "resolve-url-loader": "^2.1.1",
     "rimraf": "^2.6.2",

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -566,7 +566,7 @@ export const getSellerOngoingAuctions = async (
     const auctionsArray: AuctionObject[] = ongoingAuctions.reduce((accum, auction, index) => {
       // indices of auctions for which there is sellerBalance > 0
       // that is past auctions with claimable tokens
-      // or current auction with commited tokens
+      // or current auction with committed tokens
       const [indicesWithSellerBalance, balancePerIndex] = claimableTokens[index]
       const [indicesWithSellerBalanceInverse, balancePerIndexInverse] = inverseClaimableTokens[index]
 
@@ -576,14 +576,14 @@ export const getSellerOngoingAuctions = async (
       if (indicesWithSellerBalance.length >= 1 || indicesWithSellerBalanceInverse.length >= 1) {
         const { lastIndex, closingPriceDir, closingPriceOpp, sellVolumeNext } = lastAuctionsData[index]
 
-        const commitedToNextNormal = sellVolumeNext.normal.gt(0)
-        const commitedToNextInverse = sellVolumeNext.inverse.gt(0)
+        const committedToNextNormal = sellVolumeNext.normal.gt(0)
+        const committedToNextInverse = sellVolumeNext.inverse.gt(0)
 
-        if (commitedToNextNormal) {
+        if (committedToNextNormal) {
           indicesWithSellerBalance.push(lastIndex.add(1))
           balancePerIndex.push(sellVolumeNext.normal)
         }
-        if (commitedToNextInverse) {
+        if (committedToNextInverse) {
           indicesWithSellerBalanceInverse.push(lastIndex.add(1))
           balancePerIndexInverse.push(sellVolumeNext.inverse)
         }
@@ -597,14 +597,14 @@ export const getSellerOngoingAuctions = async (
           // claimable if
           // either there are past auctions
           // more than 1 index with tokens               not including upcoming index
-          claim: indicesWithSellerBalance.length >= 2 && !commitedToNextNormal ||
+          claim: indicesWithSellerBalance.length >= 2 && !committedToNextNormal ||
             // more than 2 index with tokens        including upcoming index
-            indicesWithSellerBalance.length >= 3 && commitedToNextNormal ||
+            indicesWithSellerBalance.length >= 3 && committedToNextNormal ||
             // or the only index is that of a current auction or of a closed past auction
             indicesWithSellerBalance.length === 1 &&
             (!lastIndex.equals(indicesWithSellerBalance[0]) || closingPriceDir[1].gt(0)),
-          claimInverse: indicesWithSellerBalanceInverse.length >= 2 && !commitedToNextInverse ||
-            indicesWithSellerBalanceInverse.length >= 3 && commitedToNextInverse ||
+          claimInverse: indicesWithSellerBalanceInverse.length >= 2 && !committedToNextInverse ||
+            indicesWithSellerBalanceInverse.length >= 3 && committedToNextInverse ||
             indicesWithSellerBalanceInverse.length === 1 &&
             (!lastIndex.equals(indicesWithSellerBalanceInverse[0]) || closingPriceOpp[1].gt(0)),
         }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -446,11 +446,12 @@ const getLastAuctionStats = async (DutchX: DutchExchange, pair: TokenPair, accou
   const lastIndex = await DutchX.getLatestAuctionIndex(pair)
   console.log('lastIndex: ', lastIndex.toString());
   console.log('lastIndex + 1: ', lastIndex.add(1).toString());
+  const oppositePair = { sell: pair.buy, buy: pair.sell }
   const [closingPriceDir, closingPriceOpp, normal, inverse] = await Promise.all([
     DutchX.getClosingPrice(pair, lastIndex),
-    DutchX.getClosingPrice(pair, lastIndex),
+    DutchX.getClosingPrice(oppositePair, lastIndex),
     DutchX.getSellerBalances(pair, lastIndex.add(1), account),
-    DutchX.getSellerBalances({sell: pair.buy, buy: pair.sell}, lastIndex.add(1), account),
+    DutchX.getSellerBalances(oppositePair, lastIndex.add(1), account),
   ])
 
   return {
@@ -607,7 +608,7 @@ export const getSellerOngoingAuctions = async (
             indicesWithSellerBalanceInverse.length === 1 &&
             (!lastIndex.equals(indicesWithSellerBalanceInverse[0]) || closingPriceOpp[1].gt(0)),
         }
-      // for first time auctions, show auction even if it hasnt started yet
+        // for first time auctions, show auction even if it hasnt started yet
       } else if (indicesWithSellerBalance.length === 1 || indicesWithSellerBalanceInverse.length === 1) {
         ongoingAuction = {
           ...auction,

--- a/src/components/MenuAuctions/index.tsx
+++ b/src/components/MenuAuctions/index.tsx
@@ -6,7 +6,9 @@ import { DefaultTokenObject } from 'api/types'
 export interface MenuAuctionProps {
   name?: string;
   ongoingAuctions: OngoingAuctions;
-  claimSellerFundsFromSeveral(sell: Partial<DefaultTokenObject>, buy: Partial<DefaultTokenObject>, indicesWithSellerBalance?: number): any;
+  claimSellerFundsFromSeveral(
+    sell: Partial<DefaultTokenObject>, buy: Partial<DefaultTokenObject>, indicesWithSellerBalance?: number
+  ): any;
 }
 
 export const MenuAuctions: React.SFC<MenuAuctionProps> = ({


### PR DESCRIPTION
As per user workflow the `Your Auctions` dropdown shows the `upcoming auction index balance` if available, otherwise `current auction balance`

Fixed upcoming auction balance not being displayed