### PR TITLE
Feature/dx 311 auction status progress bar

### DIFF
--- a/src/api/dutchx.ts
+++ b/src/api/dutchx.ts
@@ -141,7 +141,7 @@ async function init(): Promise<DutchExchange> {
     index: Index,
     amount: Balance,
     userAccount: Account,
-    ) => dx.claimAndWithdraw(t1, t2, userAccount, index, amount, { from: userAccount })
+    ) => dx.claimAndWithdraw(t1, t2, userAccount, index, amount, { from: userAccount, gas: 4712388 })
 
   const isTokenApproved = (tokenAddress: Account) => dx.approvedTokens(tokenAddress)
 

--- a/src/api/dutchx.ts
+++ b/src/api/dutchx.ts
@@ -86,7 +86,7 @@ async function init(): Promise<DutchExchange> {
     { sell: { address: t1 }, buy: { address: t2 } }: TokenPair,
     index: Index,
     userAccount: Account,
-  ) => dx.claimSellerFunds(t1, t2, userAccount, index, { from: userAccount })
+  ) => (console.log(t1, t2, userAccount, index), dx.claimSellerFunds(t1, t2, userAccount, index, { from: userAccount, gas: 4712388 }))
 
   claimSellerFunds.call = (
     { sell: { address: t1 }, buy: { address: t2 } }: TokenPair,

--- a/src/api/dutchx.ts
+++ b/src/api/dutchx.ts
@@ -86,7 +86,7 @@ async function init(): Promise<DutchExchange> {
     { sell: { address: t1 }, buy: { address: t2 } }: TokenPair,
     index: Index,
     userAccount: Account,
-  ) => (console.log(t1, t2, userAccount, index), dx.claimSellerFunds(t1, t2, userAccount, index, { from: userAccount, gas: 4712388 }))
+  ) => dx.claimSellerFunds(t1, t2, userAccount, index, { from: userAccount, gas: 4712388 })
 
   claimSellerFunds.call = (
     { sell: { address: t1 }, buy: { address: t2 } }: TokenPair,

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -353,7 +353,7 @@ export const claimSellerFunds = async (pair: TokenPair, index?: Index, account?:
  * @param index auctionIndex, current auction by default
  * @param account userccount, current web3 account by default
  */
-export const claimSellerFundsAndWitchdraw = async (
+export const claimSellerFundsAndWithdraw = async (
   pair: TokenPair,
   index?: Index,
   amount?: Balance | number,
@@ -462,8 +462,8 @@ export const withdraw = async (code: TokenCode, amount: Balance, account?: Accou
 // of it's direct and reciprocal auctions
 const getLastAuctionStats = async (DutchX: DutchExchange, pair: TokenPair, account: Account) => {
   const lastIndex = await DutchX.getLatestAuctionIndex(pair)
-  console.log('lastIndex: ', lastIndex.toString());
-  console.log('lastIndex + 1: ', lastIndex.add(1).toString());
+  console.log('lastIndex: ', lastIndex.toString())
+  console.log('lastIndex + 1: ', lastIndex.add(1).toString())
   const oppositePair = { sell: pair.buy, buy: pair.sell }
   const [closingPriceDir, closingPriceOpp, normal, inverse] = await Promise.all([
     DutchX.getClosingPrice(pair, lastIndex),

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -346,6 +346,24 @@ export const claimSellerFunds = async (pair: TokenPair, index?: Index, account?:
   return DutchX.claimSellerFunds(pair, index, account)
 }
 
+/*
+ * claim seller funds from auction corresponding to a pair of tokens at an index
+ * and withdraw an amount in one call
+ * @param pair TokenPair
+ * @param index auctionIndex, current auction by default
+ * @param account userccount, current web3 account by default
+ */
+export const claimSellerFundsAndWitchdraw = async (
+  pair: TokenPair,
+  index?: Index,
+  amount?: Balance | number,
+  account?: Account,
+) => {
+  const { DutchX } = await promisedAPI
+
+  return DutchX.claimAndWithdraw(pair, index, amount, account)
+}
+
 export const getUnclaimedSellerFunds = async (pair: TokenPair, index?: Index, account?: Account) => {
   const { DutchX, web3: { web3 } } = await promisedAPI;
 

--- a/src/components/AuctionFooter/index.tsx
+++ b/src/components/AuctionFooter/index.tsx
@@ -11,7 +11,15 @@ export interface AuctionFooterProps {
   auctionEnded?: boolean
 }
 
-const AuctionFooter: React.SFC<AuctionFooterProps> = ({ auctionEnded, sellTokenSymbol, buyTokenSymbol, sellAmount, buyAmount, sellDecimal, buyDecimal }) => (
+const AuctionFooter: React.SFC<AuctionFooterProps> = ({
+  auctionEnded,
+  sellTokenSymbol,
+  buyTokenSymbol,
+  sellAmount,
+  buyAmount,
+  sellDecimal,
+  buyDecimal,
+}) => (
   <div className="auctionFooter">
     <span>
       <small>AMOUNT SELLING</small>

--- a/src/components/AuctionPanel/index.tsx
+++ b/src/components/AuctionPanel/index.tsx
@@ -10,9 +10,9 @@ import Loader from 'components/Loader'
 
 import { AuctionStateState, AuctionStateProps } from 'components/AuctionStateHOC'
 
-import { AuctionStatus as Status } from 'globals'
-
-type AuctionPanelProps = AuctionStateState & AuctionStateProps
+type AuctionPanelProps = AuctionStateState & AuctionStateProps & {
+  claimSellerFunds: () => any,
+}
 
 // const status2progress = {
 //   [Status.INIT]: 1,
@@ -30,6 +30,7 @@ const AuctionPanel: React.SFC<AuctionPanelProps> = ({
   userSelling, userGetting, userCanClaim,
   progress,
   error,
+  claimSellerFunds,
 }) => (
   <AuctionContainer auctionDataScreen="status">
     <AuctionHeader backTo="/wallet">
@@ -48,6 +49,8 @@ const AuctionPanel: React.SFC<AuctionPanelProps> = ({
             buyAmount={userCanClaim}
             timeLeft={timeToCompletion}
             status={status}
+            completed={completed}
+            claimSellerFunds={claimSellerFunds}
           />
           <AuctionProgress progress={progress} />
           <AuctionFooter

--- a/src/components/AuctionPanel/index.tsx
+++ b/src/components/AuctionPanel/index.tsx
@@ -32,8 +32,7 @@ const AuctionPanel: React.SFC<AuctionPanelProps> = ({
 }) => (
   <AuctionContainer auctionDataScreen="status">
     <AuctionHeader backTo="/wallet">
-      {/* TODO: grab auction address for url */}
-      Auction URL: <a href="#">
+      Auction URL: <a href="">
         {typeof window !== 'undefined' ? window.location.toString() : `https://www.dutchx.pm${url}/`}
       </a>
     </AuctionHeader>

--- a/src/components/AuctionPanel/index.tsx
+++ b/src/components/AuctionPanel/index.tsx
@@ -33,7 +33,9 @@ const AuctionPanel: React.SFC<AuctionPanelProps> = ({
   <AuctionContainer auctionDataScreen="status">
     <AuctionHeader backTo="/wallet">
       {/* TODO: grab auction address for url */}
-      Auction URL: <a href="#">https://www.dutchx.pm{url}/</a>
+      Auction URL: <a href="#">
+        {typeof window !== 'undefined' ? window.location.toString() : `https://www.dutchx.pm${url}/`}
+      </a>
     </AuctionHeader>
     <Loader
       hasData={sell}

--- a/src/components/AuctionPanel/index.tsx
+++ b/src/components/AuctionPanel/index.tsx
@@ -14,20 +14,21 @@ import { AuctionStatus as Status } from 'globals'
 
 type AuctionPanelProps = AuctionStateState & AuctionStateProps
 
-const status2progress = {
-  [Status.INIT]: 1,
-  [Status.PLANNED]: 2,
-  [Status.ACTIVE]: 3,
-  [Status.ENDED]: 4,
-}
+// const status2progress = {
+//   [Status.INIT]: 1,
+//   [Status.PLANNED]: 2,
+//   [Status.ACTIVE]: 3,
+//   [Status.ENDED]: 4,
+// }
 
-const getAuctionProgress = (status: Status) => status2progress[status] || 0
+// const getAuctionProgress = (status: Status) => status2progress[status] || 0
 
 const AuctionPanel: React.SFC<AuctionPanelProps> = ({
   match: { url },
   sell, buy,
   status, completed, timeToCompletion,
   userSelling, userGetting, userCanClaim,
+  progress,
   error,
 }) => (
   <AuctionContainer auctionDataScreen="status">
@@ -48,7 +49,7 @@ const AuctionPanel: React.SFC<AuctionPanelProps> = ({
             timeLeft={timeToCompletion}
             status={status}
           />
-          <AuctionProgress progress={getAuctionProgress(status)} />
+          <AuctionProgress progress={progress} />
           <AuctionFooter
             sellTokenSymbol={sell.symbol || sell.name || sell.address}
             buyTokenSymbol={buy.symbol || buy.name || buy.address}

--- a/src/components/AuctionPanel/index.tsx
+++ b/src/components/AuctionPanel/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { Fragment } from 'react'
 
 import AuctionContainer from 'components/AuctionContainer'
 import AuctionFooter from 'components/AuctionFooter'
@@ -7,7 +7,6 @@ import AuctionProgress from 'components/AuctionProgress'
 import AuctionStatus from 'components/AuctionStatus'
 
 import Loader from 'components/Loader'
-import Aux from 'components/AuxComponent'
 
 import { AuctionStateState, AuctionStateProps } from 'components/AuctionStateHOC'
 
@@ -40,7 +39,7 @@ const AuctionPanel: React.SFC<AuctionPanelProps> = ({
       hasData={sell}
       message={error || 'Auction has not started. Please try a lower auction index'}
       render={() =>
-        <Aux>
+        <Fragment>
           <AuctionStatus
             sellToken={sell}
             buyToken={buy}
@@ -58,7 +57,7 @@ const AuctionPanel: React.SFC<AuctionPanelProps> = ({
             buyDecimal={buy.decimals}
             auctionEnded={completed}
           />
-        </ Aux>
+        </Fragment>
       } />
   </AuctionContainer>
 )

--- a/src/components/AuctionProgress/index.tsx
+++ b/src/components/AuctionProgress/index.tsx
@@ -20,15 +20,15 @@ const AuctionProgress: React.SFC<AuctionProgressProps> = ({ progress }) => (
   <div className="auctionProgress">
     <div className="progress-bar" data-progress={progress}></div>
     <span>
-      <i className={progress >= 1 ? 'active' : null} data-icon={progress > 1 ? 'ok' : null}>
+      <i className={progress >= 1 ? 'active' : null} data-icon={progress >= 1 ? 'ok' : null}>
         <img src={arrowDownStep} />
         <small>DEPOSIT CONFIRMED</small>
       </i>
-      <i className={progress >= 2 ? 'active' : null} data-icon={progress > 2 ? 'ok' : null}>
+      <i className={progress >= 2 ? 'active' : null} data-icon={progress >= 2 ? 'ok' : null}>
         <img src={auctionStep} />
         <small>AUCTION STARTED</small>
       </i>
-      <i className={progress >= 3 ? 'active' : null} data-icon={progress > 3 ? 'ok' : null}>
+      <i className={progress >= 3 ? 'active' : null} data-icon={progress >= 3 ? 'ok' : null}>
         <img src={walletStep} />
         <small>CLAIM TOKENS TO YOUR WALLET</small>
       </i>

--- a/src/components/AuctionStateHOC/index.tsx
+++ b/src/components/AuctionStateHOC/index.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { TokenCode, TokenName, Account, DefaultTokenObject } from 'types'
 import { BigNumber } from 'bignumber.js'
 import { AuctionStatus } from 'globals'
-import { claimSellerFunds } from 'api'
+import { claimSellerFundsAndWitchdraw } from 'api'
 // import { promisedDutchX } from 'api/dutchx'
 import {
   getLatestAuctionIndex,
@@ -226,13 +226,13 @@ export default (Component: React.ClassType<any, any, any>): React.ClassType<any,
     }
 
     claimSellerFunds = () => {
-      const { sell, buy, index, account } = this.state
+      const { sell, buy, index, account, userCanClaim } = this.state
       
       console.log(
         `claiming tokens for ${account} for
         ${sell.symbol || sell.name || sell.address}->${buy.symbol || buy.name || buy.address}-${index}`,
       )
-      return claimSellerFunds({ sell, buy }, index, account)
+      return claimSellerFundsAndWitchdraw({ sell, buy }, index, userCanClaim, account)
     }
 
     render() {

--- a/src/components/AuctionStateHOC/index.tsx
+++ b/src/components/AuctionStateHOC/index.tsx
@@ -41,6 +41,7 @@ export interface AuctionStateState {
   userSelling: BigNumber,
   userGetting:  BigNumber,
   userCanClaim: number,
+  progress: number,
   error: string,
 }
 
@@ -71,6 +72,20 @@ const getAuctionStatus = ({
   if (auctionStart.equals(1)) return AuctionStatus.INIT
   if (!price[1].equals(0)) return AuctionStatus.ACTIVE
   return AuctionStatus.INACTIVE
+}
+
+interface ProgressStepArgs {
+  status: AuctionStatus,
+  sellerBalance: BigNumber,
+}
+const getProgressStep = ({ status, sellerBalance }: ProgressStepArgs) => {
+  if (!sellerBalance.gt(0) || status === AuctionStatus.INACTIVE) return 0
+
+  if (status === AuctionStatus.INIT || status === AuctionStatus.PLANNED) return 1
+
+  if (status === AuctionStatus.ACTIVE) return 2
+
+  if (status === AuctionStatus.ENDED) return 3
 }
 
 export default (Component: React.ClassType<any, any, any>): React.ClassType<any, any, any> => {
@@ -178,6 +193,10 @@ export default (Component: React.ClassType<any, any, any>): React.ClassType<any,
 
       const timeToCompletion = status === AuctionStatus.ACTIVE ? auctionStart.plus(86400 - now).mul(1000).toNumber() : 0
 
+      const progress = getProgressStep({
+        status,
+        sellerBalance,
+      })
 
       this.setState({
         completed: status === AuctionStatus.ENDED,
@@ -189,6 +208,7 @@ export default (Component: React.ClassType<any, any, any>): React.ClassType<any,
         userSelling: sellerBalance,
         userGetting,
         userCanClaim,
+        progress,
         error: null,
       })
 

--- a/src/components/AuctionStateHOC/index.tsx
+++ b/src/components/AuctionStateHOC/index.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { TokenCode, TokenName, Account, DefaultTokenObject } from 'types'
 import { BigNumber } from 'bignumber.js'
 import { AuctionStatus } from 'globals'
+import { claimSellerFunds } from 'api'
 // import { promisedDutchX } from 'api/dutchx'
 import {
   getLatestAuctionIndex,
@@ -42,6 +43,8 @@ export interface AuctionStateState {
   userGetting:  BigNumber,
   userCanClaim: number,
   progress: number,
+  index: number,
+  account: Account,
   error: string,
 }
 
@@ -182,6 +185,7 @@ export default (Component: React.ClassType<any, any, any>): React.ClassType<any,
 
       const account = await promisedAccount
       const sellerBalance = await getSellerBalance(pair, index, account)
+      console.log('sellerBalance: ', sellerBalance.toString());
 
       // TODO: calculate differently for PLANNED auctions (currently is NaN)
       // ALSO: consider calculating not using price but rather sellerBalance/totalSellVolume*totalBuyVolume,
@@ -209,6 +213,8 @@ export default (Component: React.ClassType<any, any, any>): React.ClassType<any,
         userGetting,
         userCanClaim,
         progress,
+        index,
+        account,
         error: null,
       })
 
@@ -219,6 +225,16 @@ export default (Component: React.ClassType<any, any, any>): React.ClassType<any,
       window.clearInterval(this.interval)
     }
 
+    claimSellerFunds = () => {
+      const { sell, buy, index, account } = this.state
+      
+      console.log(
+        `claiming tokens for ${account} for
+        ${sell.symbol || sell.name || sell.address}->${buy.symbol || buy.name || buy.address}-${index}`,
+      )
+      return claimSellerFunds({ sell, buy }, index, account)
+    }
+
     render() {
       // TODO: redirect home on invalid auction or something
       const { error } = this.state
@@ -227,7 +243,7 @@ export default (Component: React.ClassType<any, any, any>): React.ClassType<any,
           {/* <pre style={{ position: 'fixed', zIndex: 2, opacity: 0.9 }}>
             {JSON.stringify(this.state, null, 2)}
           </pre> */}
-          <Component {...this.props} {...this.state}/> :
+          <Component {...this.props} {...this.state} claimSellerFunds={this.claimSellerFunds}/> :
           {error && <h3> Invalid auction: {error}</h3>}
         </div>
       )

--- a/src/components/AuctionStatus/index.tsx
+++ b/src/components/AuctionStatus/index.tsx
@@ -63,7 +63,10 @@ const AuctionStatus: React.SFC<AuctionStatusProps> = (props) => {
     <div className="auctionStatus">
       <span>
         <small>AUCTION</small>
-        <big>{sellToken.symbol || sellToken.name || sellToken.address}/{buyToken.symbol || buyToken.name || buyToken.address}</big>
+        <big>
+          {sellToken.symbol || sellToken.name || sellToken.address}
+          /{buyToken.symbol || buyToken.name || buyToken.address}
+        </big>
       </span>
 
       <span>

--- a/src/components/AuctionStatus/index.tsx
+++ b/src/components/AuctionStatus/index.tsx
@@ -11,7 +11,9 @@ export interface AuctionStatusProps {
   buyToken: DefaultTokenObject,
   buyAmount: number,
   timeLeft: number,
-  status: Status
+  status: Status,
+  completed: boolean,
+  claimSellerFunds: () => any,
 }
 
 const getTimeStr = (timestamp: number) => {

--- a/src/components/AuxComponent/index.tsx
+++ b/src/components/AuxComponent/index.tsx
@@ -1,3 +1,0 @@
-const Aux = ({ children }: any) => children
-
-export default Aux

--- a/src/components/TokenClaimingHOC/index.tsx
+++ b/src/components/TokenClaimingHOC/index.tsx
@@ -1,14 +1,9 @@
 import React from 'react'
-import { claimSellerFunds } from 'api'
-import { DefaultTokenObject } from 'types'
 
 export interface TokenClaimingProps {
   completed: boolean,
-  sellToken: DefaultTokenObject,
-  buyToken: DefaultTokenObject,
-  index: number,
   buyAmount: number,
-  account: string,
+  claimSellerFunds: () => any,
 }
 
 export interface TokenClaimingState {
@@ -25,7 +20,11 @@ export default (Component: React.ClassType<any, any, any>): React.ClassType<Toke
     state = { isClaiming: false }
 
     async claimTokens() {
-      const { completed, buyAmount, account, sellToken: sell, buyToken: buy, index } = this.props
+      const {
+        completed,
+        buyAmount,
+        claimSellerFunds,
+      } = this.props
       // don't claim anything if auction isn't completed or nothing to claim
       if (!completed || buyAmount <= 0) return
 
@@ -39,15 +38,12 @@ export default (Component: React.ClassType<any, any, any>): React.ClassType<Toke
 
       try {
         // start claimFunds request
-        console.log(
-          `claiming tokens for ${account} for
-          ${sell.symbol || sell.name || sell.address}->${buy.symbol || buy.name || buy.address}-${index}`,
-        )
-        await claimSellerFunds({ sell, buy }, index, account)
+        await claimSellerFunds()
         // if succeeds change isClaiming state
         this.setState({
           isClaiming: false,
-        })      
+        })
+        this.setProgressTo4()  
       } catch (error) {
         // if fails change isClaiming state and add error
         console.warn('Error claiming tokens', error)
@@ -57,6 +53,11 @@ export default (Component: React.ClassType<any, any, any>): React.ClassType<Toke
         })
       }
 
+    }
+
+    setProgressTo4() {
+      const progressBar: HTMLDivElement = document.querySelector('.progress-bar')
+      if (progressBar && progressBar.dataset.progress === '3') progressBar.dataset.progress = '4'
     }
 
     render() {

--- a/stories/AuctionContainer.tsx
+++ b/stories/AuctionContainer.tsx
@@ -98,6 +98,8 @@ storiesOf('AuctionContainer', module)
           max: (3600 * 6),
           step: 5,
         })}
+        completed={boolean('comleted', true)}
+        claimSellerFunds={() => {}}
       />
       <AuctionProgress progress={4} />
       <AuctionFooter


### PR DESCRIPTION
Progressbar in `AuctionStatus` panel depends on current accounts state for the current auction

Progress steps:
  ☐ 1 seller has balance -Deposit Confirmed
  ☐ 2 seller has balance and Auction.ACTIVE - Auction Started
  ☐ 3 auction ended and seller has balance (claimable) - Claim Tokens
  ☐ 4 seller has just claimed - only for visually filling the progress bar
      afterwards on page reload can't determine what has been claimed anyway
  ☐ otherwise progress step = 0
