### PR TITLE
Feature/DX-281-OWL-Approval

### DIFF
--- a/src/components/Modals/index.tsx
+++ b/src/components/Modals/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Modal } from 'types'
-import { closeModal, approveAndPostSellOrder } from 'actions'
+import { closeModal } from 'actions'
 
 interface TransactionModalProps {
   activeProvider?: string,
@@ -11,7 +11,6 @@ interface TransactionModalProps {
 
 interface ApprovalModalProps extends TransactionModalProps {
   approvalButton: any,
-  approveAndPostSellOrder: typeof approveAndPostSellOrder,
 }
 
 interface BlockModalProps extends TransactionModalProps {

--- a/src/components/Modals/index.tsx
+++ b/src/components/Modals/index.tsx
@@ -67,9 +67,10 @@ export const ApprovalModal: React.SFC<ApprovalModalProps> = ({
   modalProps: {
     header,
     body,
+    onClick,
+    buttons,
   },
   activeProvider,
-  approveAndPostSellOrder,
 }) =>
   <div className="modalDivStyle">
     <h1 className="modalH1">{header || 'Please choose Token Approval amount'}</h1>
@@ -80,23 +81,23 @@ export const ApprovalModal: React.SFC<ApprovalModalProps> = ({
       <div className="modalButtonDiv">
         <button
           className="modalButton"
-          onClick={() => approveAndPostSellOrder('MAX')}
+          onClick={() => onClick('MAX')}
           >
-          Approve Max
+          {buttons && buttons.button1.buttonTitle1 || 'Approve Max'}
         </button>
         <p className="modalButtonDescription">
-          Choose this option to stop seeing this prompt and only sign 1 transaction per sell order
+          {buttons && buttons.button1.buttonDesc1 || 'Choose this option to stop seeing this prompt and only sign 1 transaction per sell order'}
         </p>
       </div>
       <div className="modalButtonDiv">
         <button
           className="modalButton"
-          onClick={() => approveAndPostSellOrder('MIN')}
+          onClick={() => onClick('MIN')}
           >
-          Approve Min
+          {buttons && buttons.button2.buttonTitle2 || 'Approve Min'}
         </button>
         <p className="modalButtonDescription">
-          Choose this option to require signing 2 transactions for each sell order
+          {buttons && buttons.button2.buttonDesc2 || 'Choose this option to require signing 2 transactions for each sell order'}
         </p>
       </div>
     </div>

--- a/src/containers/Modals/index.tsx
+++ b/src/containers/Modals/index.tsx
@@ -1,7 +1,7 @@
 import React, { Component, CSSProperties } from 'react'
 
 import { connect } from 'react-redux'
-import { closeModal, approveAndPostSellOrder } from 'actions'
+import { closeModal } from 'actions'
 
 import { history } from 'components/App'
 
@@ -14,7 +14,6 @@ export interface ModalContainerProps extends Modal {
   children?: any,
 
   closeModal?: typeof closeModal,
-  submitSellOrder?: typeof approveAndPostSellOrder,
 }
 
 const backdropActive: CSSProperties = {
@@ -100,7 +99,6 @@ interface OwnProps {
 
 interface DispatchProps {
   closeModal: typeof closeModal;
-  approveAndPostSellOrder: typeof approveAndPostSellOrder;
 }
 
 const mergeProps = (stateProps: ModalContainerProps, dispatchProps: {}, ownProps: OwnProps) => ({
@@ -113,5 +111,5 @@ const mergeProps = (stateProps: ModalContainerProps, dispatchProps: {}, ownProps
 })
 
 export default connect<ModalContainerProps, DispatchProps, any>(
-  mapState, { closeModal, approveAndPostSellOrder }, mergeProps,
+  mapState, { closeModal }, mergeProps,
 )(ModalContainer)

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -63,11 +63,22 @@ export interface Modal {
   modalProps: {
     header: string,
     body: string,
+    buttons?: {
+      button1: {
+        buttonTitle1: string,
+        buttonDesc1: string,
+      },
+      button2: {
+        buttonTitle2: string,
+        buttonDesc2: string,
+      },
+    },
     txData?: {
       tokenA: DefaultTokenObject,
       tokenB?: DefaultTokenObject,
       sellAmount: Balance | BigNumber,
     },
+    onClick?: (choice: string) => any,
     button?: boolean,
     error?: string,
   }


### PR DESCRIPTION
Changes:

> synchronous biz logic for `checkUserStateAndSell`
1. fires correct modals based on user state
2. passes `accept` from `Promise` as `onClick`
3. uses response to properly fire modals
4. changed `approveAndSell` to `approveTokens` as Sell mechanism removed

> components
1. Extracted hard coded logic into props for `ApprovalModal` + types