### PR TITLE
Hotfix/dx 328 order page bugs

### DIFF
--- a/src/components/AuctionSellingGetting/index.tsx
+++ b/src/components/AuctionSellingGetting/index.tsx
@@ -18,6 +18,7 @@ class AuctionSellingGetting extends Component<AuctionSellingGettingProps> {
     const input = e.target
     const { value } = input
     const { setSellTokenAmount, maxSellAmount } = this.props
+    if (e.target.value.length < 1) return setSellTokenAmount({ sellAmount: '0' })
     setSellTokenAmount({ sellAmount: value })
 
     if (maxSellAmount.lessThanOrEqualTo(value)) {

--- a/src/containers/AuctionSellingGetting/index.ts
+++ b/src/containers/AuctionSellingGetting/index.ts
@@ -19,7 +19,7 @@ const mapState = (state: State) => {
     buyTokenSymbol: buy.symbol || buy.name || buy.address,
     sellAmount,
     // TODO: use BN.mult()
-    buyAmount: (+sellAmount * +price).toString(),
+    buyAmount: (+sellAmount * +price).toFixed(4),
   }) as AuctionSellingGettingProps
 }
 


### PR DESCRIPTION

1. setSellAmount default when empty value submitted
> when deleting values an error was throwing with BigNumber.js
2. .toFixed(4) on computed EST.Getting amounts in Order page
> computed values sometimes showing enormous decimal values