### PR TITLE
change keyName to customTokens to match name in src/integrations

### DIFF
--- a/src/components/IPFSHOC/index.tsx
+++ b/src/components/IPFSHOC/index.tsx
@@ -54,7 +54,7 @@ export default (WrappedComponent: React.SFC<any> | React.ComponentClass<any>) =>
         const customTokenListWithDecimals = await getAllTokenDecimals(json)
 
         localForage.setItem('customListHash', fileHash)
-        localForage.setItem('customTokenList', customTokenListWithDecimals)
+        localForage.setItem('customTokens', customTokenListWithDecimals)
 
         this.setState({ pullingData: false })
 


### PR DESCRIPTION
1. different key name was uploading wrong tokenList to localForage