### PR TITLE
Fix/dx 339 disable token upload again cause we cant make up our minds

### DIFF
--- a/src/components/TokenPicker/index.tsx
+++ b/src/components/TokenPicker/index.tsx
@@ -13,6 +13,7 @@ export interface TokenPickerProps {
   needsTokens: boolean;
   showPair: boolean;
   tokensSelected: boolean;
+  allowUpload: boolean;       // centralized version - set to true in reducers/tokenLists.ts when decentralised
 }
 
 const TokenPicker: React.SFC<TokenPickerProps> = ({
@@ -22,6 +23,7 @@ const TokenPicker: React.SFC<TokenPickerProps> = ({
   setTokenListType,
   showPair,
   tokensSelected,
+  allowUpload,    // TODO: centralized version - set to true in reducers/tokenLists.ts when decentralised
 }) => (
 
   <div className="tokenPicker">
@@ -35,7 +37,7 @@ const TokenPicker: React.SFC<TokenPickerProps> = ({
         <h2>Pick Token Pair Auction</h2>
         <TokenPair />
         <ButtonCTA className={!tokensSelected ? 'buttonCTA-disabled' : 'blue'} onClick={tokensSelected ? continueToOrder : (e) => e.preventDefault()} to={to}>Specify amount selling</ButtonCTA>
-        <a className="showTokenUpload" onClick={(e) => (e.preventDefault(), setTokenListType({ type: 'UPLOAD' }))}>Upload Additional Token List</a>
+        {allowUpload && <a className="showTokenUpload" onClick={(e) => (e.preventDefault(), setTokenListType({ type: 'UPLOAD' }))}>Upload Additional Token List</a>}
       </div>
     }
 

--- a/src/containers/TokenPicker/index.ts
+++ b/src/containers/TokenPicker/index.ts
@@ -12,14 +12,16 @@ const mapState = ({
     customTokenList,
     defaultTokenList,
     type,
+    allowUpload,        // TODO: centralized version - set to true in reducers/tokenLists.ts when decentralised
   },
   tokenPair: {
     sell,
     buy,
   },
 }: State) => ({
+  allowUpload,
   fileBuffer,
-  needsTokens: type === 'UPLOAD' || !(defaultTokenList.length > 0 || customTokenList.length > 0),
+  needsTokens: allowUpload && (type === 'UPLOAD' || !(defaultTokenList.length > 0 || customTokenList.length > 0)),
   tokensSelected: !!(sell && buy),
 })
 

--- a/src/reducers/tokenList.ts
+++ b/src/reducers/tokenList.ts
@@ -52,6 +52,7 @@ export default handleActions(
     defaultTokenList:   [],
     customTokenList:    [],
     combinedTokenList:  [],
-    type: 'UPLOAD',
+    type: 'DEFAULT',
+    allowUpload: false,     // TODO: centralized version - set to true in reducers/tokenLists.ts when decentralised
   },
 )

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -138,6 +138,7 @@ export interface TokenList {
   customTokenList: DefaultTokenObject[];
   combinedTokenList: DefaultTokenObject[];
   type: TokenListType['CUSTOM' | 'DEFAULT' | 'UPLOAD'];
+  allowUpload: boolean;
 }
 
 /**

--- a/stories/TokenPicker.tsx
+++ b/stories/TokenPicker.tsx
@@ -49,6 +49,6 @@ storiesOf('TokenPicker', module)
       showPair={boolean('showPair', false)}
       tokensSelected={boolean('Tokens Selected', false)}
       to=""
-
+      allowUpload={false}
     />
 ))


### PR DESCRIPTION
Changes:
1. created boolean flag for allowing or disallowing token downloads

2. passed `allowUpload` to `tokenPicker`

3. types + stories

one thing this may need is a hard-coded `defaultTokenList` again in case the IPFS gateway fetch doesnt work

¯\\_(ツ)_/¯