### PR TITLE
Feature/dx 330 2 modal claim withdraw

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4795,24 +4795,6 @@
         }
       }
     },
-    "@gnosis.pm/gnosis-core-contracts": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@gnosis.pm/gnosis-core-contracts/-/gnosis-core-contracts-1.0.4.tgz",
-      "integrity": "sha512-3C8LUH/11TDgcuB25MEsacHTR4ZlELRSAB0StsH6KXQFoz70SGdkdPSYjU7lBb9fj0JlEVFxTX84YUG2WwluAg=="
-    },
-    "@gnosis.pm/owl-token": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@gnosis.pm/owl-token/-/owl-token-0.3.0.tgz",
-      "integrity": "sha512-GK5LUYRvRvdKJ4TSy57LgtldLgs1ZBFoJ/JkYzMV5BUjR4IeYYx4p+pBJjMFxPDXrs67PwF9Us0d3rk2SJ/MNg==",
-      "requires": {
-        "@gnosis.pm/gnosis-core-contracts": "1.0.4"
-      }
-    },
-    "@gnosis.pm/pm-contracts": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@gnosis.pm/pm-contracts/-/pm-contracts-1.0.4.tgz",
-      "integrity": "sha512-dZ3wKHWDVEuysOMNICmqWt13C8ujHbe2aPneL9nhsmfjTrdQlOz3mbeZIadELzDb+kqwo8hqGuzP+u7q2Yhdsw=="
-    },
     "@gnosis.pm/util-contracts": {
       "version": "0.2.14",
       "resolved": "https://registry.npmjs.org/@gnosis.pm/util-contracts/-/util-contracts-0.2.14.tgz",
@@ -6014,7 +5996,8 @@
     "aes-js": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-0.2.4.tgz",
-      "integrity": "sha1-lLiBq3FyhtAV+iGeCPtmcJ3aWj0="
+      "integrity": "sha1-lLiBq3FyhtAV+iGeCPtmcJ3aWj0=",
+      "dev": true
     },
     "after": {
       "version": "0.8.2",
@@ -6455,7 +6438,8 @@
     "asn1": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+      "dev": true
     },
     "asn1.js": {
       "version": "5.0.1",
@@ -6478,7 +6462,8 @@
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -6519,6 +6504,7 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/async-eventemitter/-/async-eventemitter-0.2.4.tgz",
       "integrity": "sha512-pd20BwL7Yt1zwDFy+8MX8F1+WCT8aQeKj0kQnTrH9WaeRETlRamVhD0JtRPmrV4GfOJ2F9CvdQkZeZhnh2TuHw==",
+      "dev": true,
       "requires": {
         "async": "2.6.0"
       }
@@ -6537,7 +6523,8 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
     },
     "atob": {
       "version": "2.1.1",
@@ -6656,12 +6643,14 @@
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true
     },
     "aws4": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
-      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
+      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
+      "dev": true
     },
     "axobject-query": {
       "version": "0.1.0",
@@ -7870,6 +7859,7 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",
       "integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
+      "dev": true,
       "requires": {
         "babel-plugin-check-es2015-constants": "6.22.0",
         "babel-plugin-syntax-trailing-function-commas": "6.22.0",
@@ -8113,15 +8103,6 @@
         "to-fast-properties": "1.0.3"
       }
     },
-    "babelify": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
-      "integrity": "sha1-qlau3nBn/XvVSWZu4W3ChQh+iOU=",
-      "requires": {
-        "babel-core": "6.26.3",
-        "object-assign": "4.1.1"
-      }
-    },
     "babylon": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
@@ -8228,6 +8209,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "dev": true,
       "optional": true,
       "requires": {
         "tweetnacl": "0.14.5"
@@ -8481,6 +8463,7 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
       "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+      "dev": true,
       "requires": {
         "hoek": "4.2.1"
       }
@@ -8721,6 +8704,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/browserify-sha3/-/browserify-sha3-0.0.1.tgz",
       "integrity": "sha1-P/NKMAbvFcD7NWflQbkaI0ASPRE=",
+      "dev": true,
       "requires": {
         "js-sha3": "0.3.1"
       },
@@ -8728,7 +8712,8 @@
         "js-sha3": {
           "version": "0.3.1",
           "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.3.1.tgz",
-          "integrity": "sha1-hhIoAhQvCChQKg0d7h2V4lO7AkM="
+          "integrity": "sha1-hhIoAhQvCChQKg0d7h2V4lO7AkM=",
+          "dev": true
         }
       }
     },
@@ -8758,6 +8743,7 @@
       "version": "2.11.3",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
       "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
+      "dev": true,
       "requires": {
         "caniuse-lite": "1.0.30000836",
         "electron-to-chromium": "1.3.45"
@@ -9000,7 +8986,8 @@
     "camelcase": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-      "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+      "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+      "dev": true
     },
     "camelcase-keys": {
       "version": "2.1.0",
@@ -9053,7 +9040,8 @@
     "caniuse-lite": {
       "version": "1.0.30000836",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000836.tgz",
-      "integrity": "sha512-DlVR8sVTKDgd7t95U0shX3g7MeJ/DOjKOhUcaiXqnVmnO5sG4Tn2rLVOkVfPUJgnQNxnGe8/4GK0dGSI+AagQw=="
+      "integrity": "sha512-DlVR8sVTKDgd7t95U0shX3g7MeJ/DOjKOhUcaiXqnVmnO5sG4Tn2rLVOkVfPUJgnQNxnGe8/4GK0dGSI+AagQw==",
+      "dev": true
     },
     "capture-exit": {
       "version": "1.2.0",
@@ -9078,7 +9066,8 @@
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
     },
     "catbox": {
       "version": "7.1.5",
@@ -9184,6 +9173,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/checkpoint-store/-/checkpoint-store-1.1.0.tgz",
       "integrity": "sha1-BOTLUWuRQziTWB5tRgGnjpVS6gY=",
+      "dev": true,
       "requires": {
         "functional-red-black-tree": "1.0.1"
       }
@@ -9538,6 +9528,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/coinstring/-/coinstring-2.3.0.tgz",
       "integrity": "sha1-zbYzY6lhUCQEolr7gsLibV/2J6Q=",
+      "dev": true,
       "requires": {
         "bs58": "2.0.1",
         "create-hash": "1.2.0"
@@ -9546,7 +9537,8 @@
         "bs58": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/bs58/-/bs58-2.0.1.tgz",
-          "integrity": "sha1-VZCNWPGYKrogCPob7Y+RmYopv40="
+          "integrity": "sha1-VZCNWPGYKrogCPob7Y+RmYopv40=",
+          "dev": true
         }
       }
     },
@@ -9635,6 +9627,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+      "dev": true,
       "requires": {
         "delayed-stream": "1.0.0"
       }
@@ -10395,6 +10388,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
       "requires": {
         "assert-plus": "1.0.0"
       }
@@ -10652,7 +10646,8 @@
     "defined": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
+      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+      "dev": true
     },
     "del": {
       "version": "2.2.2",
@@ -10688,7 +10683,8 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
     },
     "delegates": {
       "version": "1.0.0",
@@ -11020,6 +11016,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "dev": true,
       "optional": true,
       "requires": {
         "jsbn": "0.1.1"
@@ -11077,7 +11074,8 @@
     "electron-to-chromium": {
       "version": "1.3.45",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.45.tgz",
-      "integrity": "sha1-RYrBscXHYM6IEaFtK/vZfsMLr7g="
+      "integrity": "sha1-RYrBscXHYM6IEaFtK/vZfsMLr7g=",
+      "dev": true
     },
     "elegant-spinner": {
       "version": "1.0.1",
@@ -12007,43 +12005,6 @@
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
     },
-    "eth-block-tracker": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/eth-block-tracker/-/eth-block-tracker-2.3.1.tgz",
-      "integrity": "sha512-NamWuMBIl8kmkJFVj8WzGatySTzQPQag4Xr677yFxdVtIxACFbL/dQowk0MzEqIKk93U1TwY3MjVU6mOcwZnKA==",
-      "requires": {
-        "async-eventemitter": "github:ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c",
-        "eth-query": "2.1.2",
-        "ethereumjs-tx": "1.3.4",
-        "ethereumjs-util": "5.2.0",
-        "ethjs-util": "0.1.4",
-        "json-rpc-engine": "3.7.3",
-        "pify": "2.3.0",
-        "tape": "4.9.0"
-      },
-      "dependencies": {
-        "async-eventemitter": {
-          "version": "github:ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c",
-          "requires": {
-            "async": "2.6.0"
-          }
-        },
-        "ethereumjs-util": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-          "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
-          "requires": {
-            "bn.js": "4.11.6",
-            "create-hash": "1.2.0",
-            "ethjs-util": "0.1.4",
-            "keccak": "1.4.0",
-            "rlp": "2.0.0",
-            "safe-buffer": "5.1.2",
-            "secp256k1": "3.5.0"
-          }
-        }
-      }
-    },
     "eth-hash-to-cid": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/eth-hash-to-cid/-/eth-hash-to-cid-0.1.1.tgz",
@@ -12053,67 +12014,10 @@
         "multihashes": "0.4.13"
       }
     },
-    "eth-query": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/eth-query/-/eth-query-2.1.2.tgz",
-      "integrity": "sha1-1nQdkAAQa1FRDHLbktY2VFam2l4=",
-      "requires": {
-        "json-rpc-random-id": "1.0.1",
-        "xtend": "4.0.1"
-      }
-    },
-    "eth-sig-util": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
-      "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
-      "requires": {
-        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#4ea2fdfed09e8f99117d9362d17c6b01b64a2bcf",
-        "ethereumjs-util": "5.2.0"
-      },
-      "dependencies": {
-        "ethereumjs-util": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-          "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
-          "requires": {
-            "bn.js": "4.11.6",
-            "create-hash": "1.2.0",
-            "ethjs-util": "0.1.4",
-            "keccak": "1.4.0",
-            "rlp": "2.0.0",
-            "safe-buffer": "5.1.2",
-            "secp256k1": "3.5.0"
-          }
-        }
-      }
-    },
     "ethereum-common": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.2.0.tgz",
       "integrity": "sha512-XOnAR/3rntJgbCdGhqdaLIxDLWKLmsZOGhHdBKadEr6gEnJLH52k93Ou+TUdFaPN3hJc3isBZBal3U/XZ15abA=="
-    },
-    "ethereumjs-abi": {
-      "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#4ea2fdfed09e8f99117d9362d17c6b01b64a2bcf",
-      "requires": {
-        "bn.js": "4.11.6",
-        "ethereumjs-util": "5.2.0"
-      },
-      "dependencies": {
-        "ethereumjs-util": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-          "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
-          "requires": {
-            "bn.js": "4.11.6",
-            "create-hash": "1.2.0",
-            "ethjs-util": "0.1.4",
-            "keccak": "1.4.0",
-            "rlp": "2.0.0",
-            "safe-buffer": "5.1.2",
-            "secp256k1": "3.5.0"
-          }
-        }
-      }
     },
     "ethereumjs-account": {
       "version": "2.0.5",
@@ -12203,6 +12107,7 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
       "integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
+      "dev": true,
       "requires": {
         "bn.js": "4.11.6",
         "create-hash": "1.2.0",
@@ -12215,6 +12120,7 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-2.3.5.tgz",
       "integrity": "sha512-AJ7x44+xqyE5+UO3Nns19WkTdZfyqFZ+sEjIEpvme7Ipbe3iBU1uwCcHEdiu/yY9bdhr3IfSa/NfIKNeXPaRVQ==",
+      "dev": true,
       "requires": {
         "async": "2.6.0",
         "async-eventemitter": "0.2.4",
@@ -12233,6 +12139,7 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
           "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+          "dev": true,
           "requires": {
             "bn.js": "4.11.6",
             "create-hash": "1.2.0",
@@ -12249,6 +12156,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/ethereumjs-wallet/-/ethereumjs-wallet-0.6.0.tgz",
       "integrity": "sha1-gnY7Fpfuenlr5xVdqd+0my+Yz9s=",
+      "dev": true,
       "requires": {
         "aes-js": "0.2.4",
         "bs58check": "1.3.4",
@@ -12262,7 +12170,8 @@
         "uuid": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
+          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
+          "dev": true
         }
       }
     },
@@ -12631,7 +12540,8 @@
     "extend": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+      "dev": true
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -12794,12 +12704,14 @@
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
     },
     "fake-merkle-patricia-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fake-merkle-patricia-tree/-/fake-merkle-patricia-tree-1.0.1.tgz",
       "integrity": "sha1-S4w6z7Ugr635hgsfFM2M40As3dM=",
+      "dev": true,
       "requires": {
         "checkpoint-store": "1.1.0"
       }
@@ -13306,14 +13218,6 @@
         "pend": "1.2.0"
       }
     },
-    "fetch-ponyfill": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/fetch-ponyfill/-/fetch-ponyfill-4.1.0.tgz",
-      "integrity": "sha1-rjzl9zLGReq4fkroeTQUcJsjmJM=",
-      "requires": {
-        "node-fetch": "1.7.3"
-      }
-    },
     "figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
@@ -13549,6 +13453,7 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.2.tgz",
       "integrity": "sha1-LEBFC5NI6X8oEyJZO6lnBLmr1NQ=",
+      "dev": true,
       "requires": {
         "is-function": "1.0.1"
       }
@@ -13574,12 +13479,14 @@
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
     },
     "form-data": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+      "dev": true,
       "requires": {
         "asynckit": "0.4.0",
         "combined-stream": "1.0.6",
@@ -13640,6 +13547,7 @@
       "version": "0.30.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
       "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
+      "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
         "jsonfile": "2.4.0",
@@ -14378,6 +14286,7 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
       "requires": {
         "assert-plus": "1.0.0"
       }
@@ -14796,12 +14705,14 @@
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
     },
     "har-validator": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+      "dev": true,
       "requires": {
         "ajv": "5.5.2",
         "har-schema": "2.0.0"
@@ -14952,6 +14863,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
       "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+      "dev": true,
       "requires": {
         "boom": "4.3.1",
         "cryptiles": "3.1.2",
@@ -14963,6 +14875,7 @@
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/hdkey/-/hdkey-0.7.1.tgz",
       "integrity": "sha1-yu5L6BqneSHpCbjSKN0PKayu5jI=",
+      "dev": true,
       "requires": {
         "coinstring": "2.3.0",
         "secp256k1": "3.5.0"
@@ -15393,6 +15306,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "jsprim": "1.4.1",
@@ -16813,11 +16727,6 @@
         "number-is-nan": "1.0.1"
       }
     },
-    "is-fn": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fn/-/is-fn-1.0.0.tgz",
-      "integrity": "sha1-lUPV3nvPWwiiLsiiC65uKG1RDYw="
-    },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
@@ -16829,7 +16738,8 @@
     "is-function": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
-      "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
+      "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU=",
+      "dev": true
     },
     "is-glob": {
       "version": "2.0.1",
@@ -17112,7 +17022,8 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
     },
     "is-unc-path": {
       "version": "0.1.2",
@@ -17188,7 +17099,8 @@
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
     },
     "istanbul-api": {
       "version": "1.3.1",
@@ -18769,6 +18681,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true,
       "optional": true
     },
     "jscodeshift": {
@@ -18932,36 +18845,11 @@
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
     },
-    "json-rpc-engine": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/json-rpc-engine/-/json-rpc-engine-3.7.3.tgz",
-      "integrity": "sha512-+FO3UWu/wafh/+MZ6BXy0HZU+f5plwUn82FgxpC0scJkEh5snOjFrAAtqCITPDfvfLHRUFOG5pQDUx2pspfERQ==",
-      "requires": {
-        "async": "2.6.0",
-        "babel-preset-env": "1.6.1",
-        "babelify": "7.3.0",
-        "clone": "2.1.1",
-        "json-rpc-error": "2.0.0",
-        "promise-to-callback": "1.0.0"
-      }
-    },
-    "json-rpc-error": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/json-rpc-error/-/json-rpc-error-2.0.0.tgz",
-      "integrity": "sha1-p6+cICg4tekFxyUOVH8a/3cligI=",
-      "requires": {
-        "inherits": "2.0.3"
-      }
-    },
-    "json-rpc-random-id": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-rpc-random-id/-/json-rpc-random-id-1.0.1.tgz",
-      "integrity": "sha1-uknZat7RRE27jaPSA3SKy7zeyMg="
-    },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
     },
     "json-schema-traverse": {
       "version": "0.3.1",
@@ -18972,6 +18860,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "dev": true,
       "requires": {
         "jsonify": "0.0.0"
       }
@@ -19010,6 +18899,7 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+      "dev": true,
       "requires": {
         "graceful-fs": "4.1.11"
       }
@@ -19017,7 +18907,8 @@
     "jsonify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "dev": true
     },
     "jsonpointer": {
       "version": "4.0.1",
@@ -19035,6 +18926,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -19441,6 +19333,7 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/keccakjs/-/keccakjs-0.2.1.tgz",
       "integrity": "sha1-HWM6+QfvMFu/ny+mFtVsRFYd+k0=",
+      "dev": true,
       "requires": {
         "browserify-sha3": "0.0.1",
         "sha3": "1.2.2"
@@ -19480,6 +19373,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+      "dev": true,
       "requires": {
         "graceful-fs": "4.1.11"
       }
@@ -21138,7 +21032,8 @@
     "lodash.assign": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+      "dev": true
     },
     "lodash.camelcase": {
       "version": "4.3.0",
@@ -21816,7 +21711,8 @@
     "memorystream": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
-      "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI="
+      "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
+      "dev": true
     },
     "meow": {
       "version": "3.7.0",
@@ -22981,7 +22877,8 @@
     "oauth-sign": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+      "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
@@ -23024,7 +22921,8 @@
     "object-inspect": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.5.0.tgz",
-      "integrity": "sha512-UmOFbHbwvv+XHj7BerrhVq+knjceBdkvU5AriwLMvhv2qi+e7DJzxfBeFpILEjVzCp+xA+W/pIf06RGPWlZNfw=="
+      "integrity": "sha512-UmOFbHbwvv+XHj7BerrhVq+knjceBdkvU5AriwLMvhv2qi+e7DJzxfBeFpILEjVzCp+xA+W/pIf06RGPWlZNfw==",
+      "dev": true
     },
     "object-keys": {
       "version": "0.4.0",
@@ -23252,6 +23150,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "dev": true,
       "requires": {
         "lcid": "1.0.0"
       }
@@ -23458,6 +23357,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.1.tgz",
       "integrity": "sha1-aug6eqJanZtwCswoaYzR8e1+lTY=",
+      "dev": true,
       "requires": {
         "for-each": "0.3.2",
         "trim": "0.0.1"
@@ -23767,7 +23667,8 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
     },
     "pez": {
       "version": "2.1.5",
@@ -25454,15 +25355,6 @@
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
     },
-    "promise-to-callback": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/promise-to-callback/-/promise-to-callback-1.0.0.tgz",
-      "integrity": "sha1-XSp0kBC/tn2WNZj805YHRqaP7vc=",
-      "requires": {
-        "is-fn": "1.0.0",
-        "set-immediate-shim": "1.0.1"
-      }
-    },
     "promise.prototype.finally": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/promise.prototype.finally/-/promise.prototype.finally-3.1.0.tgz",
@@ -26980,6 +26872,7 @@
       "version": "2.85.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
       "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
+      "dev": true,
       "requires": {
         "aws-sign2": "0.7.0",
         "aws4": "1.7.0",
@@ -27022,7 +26915,8 @@
     "require-from-string": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
-      "integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg="
+      "integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg=",
+      "dev": true
     },
     "require-main-filename": {
       "version": "1.0.1",
@@ -27188,6 +27082,7 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
       "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
+      "dev": true,
       "requires": {
         "through": "2.3.8"
       }
@@ -27316,7 +27211,8 @@
     "rustbn.js": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.1.2.tgz",
-      "integrity": "sha512-bAkNqSHYdJdFsBC7Z11JgzYktL31HIpB2o70jZcGiL1U1TVtPyvaVhDrGWwS8uZtaqwW2k6NOPGZCqW/Dgh5Lg=="
+      "integrity": "sha512-bAkNqSHYdJdFsBC7Z11JgzYktL31HIpB2o70jZcGiL1U1TVtPyvaVhDrGWwS8uZtaqwW2k6NOPGZCqW/Dgh5Lg==",
+      "dev": true
     },
     "rx-lite": {
       "version": "4.0.8",
@@ -27512,6 +27408,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/scrypt/-/scrypt-6.0.3.tgz",
       "integrity": "sha1-BOAUpWgrU/pQwtXM4WfXGcBthw0=",
+      "dev": true,
       "requires": {
         "nan": "2.10.0"
       }
@@ -27520,6 +27417,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/scrypt.js/-/scrypt.js-0.2.0.tgz",
       "integrity": "sha1-r40UZbcemZARC+38WTuUeeA6ito=",
+      "dev": true,
       "requires": {
         "scrypt": "6.0.3",
         "scryptsy": "1.2.1"
@@ -27529,6 +27427,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/scryptsy/-/scryptsy-1.2.1.tgz",
       "integrity": "sha1-oyJfpLJST4AnAHYeKFW987LZIWM=",
+      "dev": true,
       "requires": {
         "pbkdf2": "3.0.16"
       }
@@ -27773,6 +27672,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/sha3/-/sha3-1.2.2.tgz",
       "integrity": "sha1-pmxQmN5MJbyIM27ItIF9AFvKe6k=",
+      "dev": true,
       "requires": {
         "nan": "2.10.0"
       }
@@ -28044,6 +27944,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
       "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+      "dev": true,
       "requires": {
         "hoek": "4.2.1"
       }
@@ -28171,6 +28072,7 @@
       "version": "0.4.23",
       "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.23.tgz",
       "integrity": "sha512-AT7anLHY6uIRg2It6N0UlCHeZ7YeecIkUhnlirrCgCPCUevtnoN48BxvgigN/4jJTRljv5oFhAJtI6gvHzT5DQ==",
+      "dev": true,
       "requires": {
         "fs-extra": "0.30.0",
         "memorystream": "0.3.1",
@@ -28345,6 +28247,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
       "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
+      "dev": true,
       "requires": {
         "asn1": "0.2.3",
         "assert-plus": "1.0.0",
@@ -28662,6 +28565,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
       "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
+      "dev": true,
       "requires": {
         "define-properties": "1.1.2",
         "es-abstract": "1.11.0",
@@ -28699,7 +28603,8 @@
     "stringstream": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+      "dev": true
     },
     "strip-ansi": {
       "version": "3.0.1",
@@ -29417,6 +29322,7 @@
       "version": "4.9.0",
       "resolved": "https://registry.npmjs.org/tape/-/tape-4.9.0.tgz",
       "integrity": "sha512-j0jO9BiScfqtPBb9QmPLL0qvxXMz98xjkMb7x8lKipFlJZwNJkqkWPou+NU4V6T9RnVh1kuSthLE8gLrN8bBfw==",
+      "dev": true,
       "requires": {
         "deep-equal": "1.0.1",
         "defined": "1.0.0",
@@ -29727,6 +29633,7 @@
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
       "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+      "dev": true,
       "requires": {
         "punycode": "1.4.1"
       }
@@ -29745,7 +29652,8 @@
     "trim": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
+      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
+      "dev": true
     },
     "trim-newlines": {
       "version": "1.0.0",
@@ -29859,59 +29767,6 @@
             "utf8": "2.1.2",
             "xhr2": "0.1.4",
             "xmlhttprequest": "1.8.0"
-          }
-        }
-      }
-    },
-    "truffle-hdwallet-provider-privkey": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/truffle-hdwallet-provider-privkey/-/truffle-hdwallet-provider-privkey-0.2.0.tgz",
-      "integrity": "sha512-p4dCmB/roQaHaRMe7Ihej4/Cdmq7Usi6aZsPv/cc2x7S5bYLSwwpgQBdjz4PjPSgNh8zqLte6ZhWkkW1CEq1iQ==",
-      "requires": {
-        "ethereumjs-tx": "1.3.4",
-        "ethereumjs-wallet": "0.6.0",
-        "web3": "0.20.6",
-        "web3-provider-engine": "13.8.0"
-      },
-      "dependencies": {
-        "ethereumjs-util": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-          "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
-          "requires": {
-            "bn.js": "4.11.6",
-            "create-hash": "1.2.0",
-            "ethjs-util": "0.1.4",
-            "keccak": "1.4.0",
-            "rlp": "2.0.0",
-            "safe-buffer": "5.1.2",
-            "secp256k1": "3.5.0"
-          }
-        },
-        "web3-provider-engine": {
-          "version": "13.8.0",
-          "resolved": "https://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-13.8.0.tgz",
-          "integrity": "sha512-fZXhX5VWwWpoFfrfocslyg6P7cN3YWPG/ASaevNfeO80R+nzgoPUBXcWQekSGSsNDkeRTis4aMmpmofYf1TNtQ==",
-          "requires": {
-            "async": "2.6.0",
-            "clone": "2.1.1",
-            "eth-block-tracker": "2.3.1",
-            "eth-sig-util": "1.4.2",
-            "ethereumjs-block": "1.7.1",
-            "ethereumjs-tx": "1.3.4",
-            "ethereumjs-util": "5.2.0",
-            "ethereumjs-vm": "2.3.5",
-            "fetch-ponyfill": "4.1.0",
-            "json-rpc-error": "2.0.0",
-            "json-stable-stringify": "1.0.1",
-            "promise-to-callback": "1.0.0",
-            "readable-stream": "2.3.6",
-            "request": "2.85.0",
-            "semaphore": "1.1.0",
-            "solc": "0.4.23",
-            "tape": "4.9.0",
-            "xhr": "2.4.1",
-            "xtend": "4.0.1"
           }
         }
       }
@@ -30232,6 +30087,7 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true,
       "optional": true
     },
     "type-check": {
@@ -30933,6 +30789,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
@@ -32071,7 +31928,8 @@
     "which-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
+      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+      "dev": true
     },
     "which-pm-runs": {
       "version": "1.0.0",
@@ -32134,7 +31992,8 @@
     "window-size": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-      "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
+      "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
+      "dev": true
     },
     "wordwrap": {
       "version": "0.0.3",
@@ -32231,6 +32090,7 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.4.1.tgz",
       "integrity": "sha512-pAIU5vBr9Hiy5cpFIbPnwf0C18ZF86DBsZKrlsf87N5De/JbA6RJ83UP/cv+aljl4S40iRVMqP4pr4sF9Dnj0A==",
+      "dev": true,
       "requires": {
         "global": "4.3.2",
         "is-function": "1.0.1",
@@ -32305,6 +32165,7 @@
       "version": "4.8.1",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
       "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
+      "dev": true,
       "requires": {
         "cliui": "3.2.0",
         "decamelize": "1.2.0",
@@ -32326,6 +32187,7 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
       "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
+      "dev": true,
       "requires": {
         "camelcase": "3.0.0",
         "lodash.assign": "4.2.0"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "precommit": "lint-staged",
     "storybook": "start-storybook -s ./ -p 6006",
     "build-storybook": "build-storybook",
-    "add2ipfs": "node ./scripts/add2ipfs.js"
+    "add2ipfs": "node ./scripts/add2ipfs.js",
+    "simulateAuction": "cd ./node_modules/@gnosis.pm/dx-contracts && truffle exec test/trufflescripts/add_token_pair.js --pair eth,gno && truffle exec test/trufflescripts/deposit.js -a '0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1' --gno 20000e18 && truffle exec test/trufflescripts/increase_time.js -h 8 && truffle exec test/trufflescripts/buy_order.js -a '0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1' -n 100e18 && truffle exec test/trufflescripts/increase_time.js -h 1"
   },
   "lint-staged": {
     "@(src|test)/**/*.js?(x)": [

--- a/src/actions/blockchain.ts
+++ b/src/actions/blockchain.ts
@@ -21,6 +21,7 @@ import {
   claimSellerFundsFromSeveralAuctions,
   getIndicesWithClaimableTokensForSellers,
   getLatestAuctionIndex,
+  withdraw,
 } from 'api'
 
 import {
@@ -451,7 +452,16 @@ export const claimSellerFundsFromSeveral = (
     }))
     const claimReceipt = await claimSellerFundsFromSeveralAuctions(sell, buy, currentAccount, lastNIndex)
     console.log('​Claim receipt => ', claimReceipt)
-
+    dispatch(openModal({
+      modalName: 'TransactionModal',
+      modalProps: {
+        header: `Withdrawing Claimed Funds`,
+        body: `Withdrawing ${buyName} tokens from ${sellName}-${buyName} auction. Please check ${activeProvider}`,
+        loader: true,
+      },
+    }))
+    const withdrawReceipt = await withdraw(buy.address)
+    console.log('​withdrawReceipt => ', withdrawReceipt)
     // refresh state ...
     let [, sellBalance] = await dispatch(updateMainAppState({ fn: getIndicesWithClaimableTokensForSellers, args: [{ sell, buy }, currentAccount, 0] }))
     // loop until sellBalance drops to 0

--- a/src/integrations/walletIntegration.ts
+++ b/src/integrations/walletIntegration.ts
@@ -22,6 +22,8 @@ import { checkTokenListJSON } from 'api/utils'
 import { getAllTokenDecimals, getApprovedTokensFromAllTokens } from 'api'
 
 import { DefaultTokens, DefaultTokenObject } from 'api/types'
+import tokensMap from 'api/apiTesting'
+
 import { TokenPair, State } from 'types'
 import { ConnectedInterface } from './types'
 
@@ -52,8 +54,14 @@ export default async function walletIntegration(store: Store<any>) {
     const isDefaultTokensAvailable = !!(defaultTokens)
 
     if (!isDefaultTokensAvailable) {
-      // grab tokens from IPFSHash
-      defaultTokens = await ipfsFetchFromHash('QmVLmtt3obCz17BDiDsGAn9gWVF1Cyxv3KyvqHrSYfFsG8') as DefaultTokens
+      // grab tokens from IPFSHash or api/apiTesting depending on NODE_ENV
+      if (process.env.NODE_ENV === 'development') {
+        defaultTokens = await tokensMap()
+      } else {
+        defaultTokens = await ipfsFetchFromHash('QmVLmtt3obCz17BDiDsGAn9gWVF1Cyxv3KyvqHrSYfFsG8') as DefaultTokens
+      }
+      
+      console.log('​getTokenList -> ', defaultTokens)
       // set tokens to localForage
       await localForage.setItem('defaultTokens', defaultTokens)
     }


### PR DESCRIPTION
1. `npm simulateAuction` works to add `eth/gno` via `addTokenPair` then `deposit` `gno` into `master` acount from `npm run rpc` then `increaseTime` + 8 hours > `buy_order` 100 `gno` then `increaseTime` again
2. `withraw` fn can either withdraw passed in amt or all if no amt passed
3. Modal pop up for claiming then another for `withdraw`
4. `defaultTokens` pulled from `tokensMap` conditionally on `NODE_ENV`