### PR TITLE
Fix/order refresh

### DIFF
--- a/src/components/AuctionPriceBar/index.tsx
+++ b/src/components/AuctionPriceBar/index.tsx
@@ -9,10 +9,16 @@ export interface AuctionPriceBarProps {
   sellTokenPrice: Balance,
 }
 
-const AuctionPriceBar: React.SFC<AuctionPriceBarProps> = ({ sellTokenSymbol, sellTokenPrice, buyTokenSymbol, header }) => 
-  <div className="auctionLastPrice">
-    <small>{`${header} of last auction:`}</small>
-    <big>{`1 ${sellTokenSymbol} = ${sellTokenPrice} ${buyTokenSymbol}`}</big>
-  </div>
+const AuctionPriceBar: React.SFC<AuctionPriceBarProps> = ({ sellTokenSymbol, sellTokenPrice, buyTokenSymbol, header }) => {
+  if (!sellTokenSymbol || !buyTokenSymbol) return null
+
+  return (
+    <div className="auctionLastPrice">
+      <small>{`${header} of last auction:`}</small>
+      {sellTokenSymbol && buyTokenSymbol && <big>{`1 ${sellTokenSymbol} = ${sellTokenPrice} ${buyTokenSymbol}`}</big>}
+    </div>
+  )
+}
+
 
 export default AuctionPriceBar

--- a/src/components/AuctionSellingGetting/index.tsx
+++ b/src/components/AuctionSellingGetting/index.tsx
@@ -54,6 +54,7 @@ class AuctionSellingGetting extends Component<AuctionSellingGettingProps> {
           min="0"
           /* max={maxSellAmount.toString()} */
           step="0.0001"
+          disabled={!sellTokenSymbol}
         />
         <small>{sellTokenSymbol}</small>
 

--- a/src/components/OrderPanel/index.tsx
+++ b/src/components/OrderPanel/index.tsx
@@ -23,7 +23,7 @@ const OrderPanel: React.SFC<OrderPanelProps> = ({ sellTokenSymbol, buyTokenSymbo
     </AuctionHeader>
 
     {/* Display 'pair-noMGN' when this pair won't generate MGN tokens (any of the picked token causing this) */}
-    {!generatesMGN && <div className="pair-noMGN">Note: this token pair won't generate MGN tokens</div>}
+    {sellTokenSymbol && buyTokenSymbol && !generatesMGN && <div className="pair-noMGN">Note: this token pair won't generate MGN tokens</div>}
     {/* END */}
 
     <TokenPair />

--- a/src/containers/AuctionPriceBar/index.ts
+++ b/src/containers/AuctionPriceBar/index.ts
@@ -3,11 +3,12 @@ import { connect } from 'react-redux'
 import { State } from 'types'
 
 import AuctionPriceBar from 'components/AuctionPriceBar'
+import { EMPTY_TOKEN } from 'globals';
 
 // TODO: create state for lastAuctionPrice for each token
 const mapState = (state: State) => {
   // TODO: change price acquisition
-  const { buy, sell, lastPrice: price } = state.tokenPair
+  const { buy = EMPTY_TOKEN, sell = EMPTY_TOKEN, lastPrice: price } = state.tokenPair
 
   return {
     sellTokenSymbol: sell.symbol || sell.name || sell.address,

--- a/src/containers/AuctionSellingGetting/index.ts
+++ b/src/containers/AuctionSellingGetting/index.ts
@@ -1,13 +1,13 @@
 import { connect } from 'react-redux'
 import { setSellTokenAmount } from 'actions'
+import { getSellTokenBalance } from 'selectors'
 
 import { State } from 'types'
 import AuctionSellingGetting, { AuctionSellingGettingProps } from 'components/AuctionSellingGetting'
 
 const mapState = (state: State) => {
   // TODO: always have some price for every pair in RatioPairs
-  const { sell, buy, lastPrice: price } = state.tokenPair
-  const { [sell.address]: sellTokenBalance } = state.tokenBalances
+  const sellTokenBalance = getSellTokenBalance(state)
   const { sellAmount } = state.tokenPair
   const maxSellAmount = sellTokenBalance.div(10 ** sell.decimals)
 

--- a/src/containers/AuctionSellingGetting/index.ts
+++ b/src/containers/AuctionSellingGetting/index.ts
@@ -1,12 +1,14 @@
 import { connect } from 'react-redux'
 import { setSellTokenAmount } from 'actions'
 import { getSellTokenBalance } from 'selectors'
+import { EMPTY_TOKEN } from 'globals'
 
 import { State } from 'types'
 import AuctionSellingGetting, { AuctionSellingGettingProps } from 'components/AuctionSellingGetting'
 
 const mapState = (state: State) => {
   // TODO: always have some price for every pair in RatioPairs
+  const { sell = EMPTY_TOKEN, buy = EMPTY_TOKEN, lastPrice: price } = state.tokenPair
   const sellTokenBalance = getSellTokenBalance(state)
   const { sellAmount } = state.tokenPair
   const maxSellAmount = sellTokenBalance.div(10 ** sell.decimals)

--- a/src/containers/OrderPanel/index.ts
+++ b/src/containers/OrderPanel/index.ts
@@ -13,10 +13,12 @@ const mapStateToProps = (state: State) => {
   // const { sellAmount } = state.tokenPair
   const maxSellAmount: BigNumber = sellTokenBalance.div(10 ** sell.decimals)
 
+  const validTokens = sell !== EMPTY_TOKEN && buy !== EMPTY_TOKEN
+
   return {
     sellTokenSymbol: sell.symbol || sell.name || sell.address,
     buyTokenSymbol: buy.symbol || buy.name || buy.address,
-    validSellAmount: +sellAmount > 0 && maxSellAmount.greaterThanOrEqualTo(sellAmount),
+    validSellAmount: validTokens && +sellAmount > 0 && maxSellAmount.greaterThanOrEqualTo(sellAmount),
     generatesMGN: isTokenApproved(state),
   }
 }

--- a/src/containers/OrderPanel/index.ts
+++ b/src/containers/OrderPanel/index.ts
@@ -1,15 +1,18 @@
 import { connect } from 'react-redux'
 import OrderPanel from 'components/OrderPanel'
 import { State, BigNumber } from 'types'
+import { getSellTokenBalance } from 'selectors'
 
 const isTokenApproved = ({ approvedTokens, tokenPair: { sell, buy } }: State) =>
   approvedTokens.has(sell.address) && approvedTokens.has(buy.address)
 
 const mapStateToProps = (state: State) => {
-  const { tokenPair: { sell, buy, sellAmount } } = state
-  const { [sell.address]: sellTokenBalance } = state.tokenBalances
+  console.log('sell: ', sell);
+  const sellTokenBalance = getSellTokenBalance(state)
+  console.log('sellTokenBalance: ', sellTokenBalance);
   // const { sellAmount } = state.tokenPair
   const maxSellAmount: BigNumber = sellTokenBalance.div(10 ** sell.decimals)
+  console.log('maxSellAmount: ', maxSellAmount);
 
   return {
     sellTokenSymbol: sell.symbol || sell.name || sell.address,

--- a/src/containers/OrderPanel/index.ts
+++ b/src/containers/OrderPanel/index.ts
@@ -9,12 +9,9 @@ const isTokenApproved = ({ approvedTokens, tokenPair: { sell = EMPTY_TOKEN, buy 
 
 const mapStateToProps = (state: State) => {
   const { tokenPair: { sell = EMPTY_TOKEN, buy = EMPTY_TOKEN, sellAmount } } = state
-  console.log('sell: ', sell);
   const sellTokenBalance = getSellTokenBalance(state)
-  console.log('sellTokenBalance: ', sellTokenBalance);
   // const { sellAmount } = state.tokenPair
   const maxSellAmount: BigNumber = sellTokenBalance.div(10 ** sell.decimals)
-  console.log('maxSellAmount: ', maxSellAmount);
 
   return {
     sellTokenSymbol: sell.symbol || sell.name || sell.address,

--- a/src/containers/OrderPanel/index.ts
+++ b/src/containers/OrderPanel/index.ts
@@ -2,11 +2,13 @@ import { connect } from 'react-redux'
 import OrderPanel from 'components/OrderPanel'
 import { State, BigNumber } from 'types'
 import { getSellTokenBalance } from 'selectors'
+import { EMPTY_TOKEN } from 'globals';
 
 const isTokenApproved = ({ approvedTokens, tokenPair: { sell, buy } }: State) =>
   approvedTokens.has(sell.address) && approvedTokens.has(buy.address)
 
 const mapStateToProps = (state: State) => {
+  const { tokenPair: { sell = EMPTY_TOKEN, buy = EMPTY_TOKEN, sellAmount } } = state
   console.log('sell: ', sell);
   const sellTokenBalance = getSellTokenBalance(state)
   console.log('sellTokenBalance: ', sellTokenBalance);

--- a/src/containers/OrderPanel/index.ts
+++ b/src/containers/OrderPanel/index.ts
@@ -4,7 +4,7 @@ import { State, BigNumber } from 'types'
 import { getSellTokenBalance } from 'selectors'
 import { EMPTY_TOKEN } from 'globals';
 
-const isTokenApproved = ({ approvedTokens, tokenPair: { sell, buy } }: State) =>
+const isTokenApproved = ({ approvedTokens, tokenPair: { sell = EMPTY_TOKEN, buy = EMPTY_TOKEN } }: State) =>
   approvedTokens.has(sell.address) && approvedTokens.has(buy.address)
 
 const mapStateToProps = (state: State) => {

--- a/src/globals/index.ts
+++ b/src/globals/index.ts
@@ -1,4 +1,4 @@
-import { Code2Name, TokenCode, Network2URL } from 'types'
+import { Code2Name, TokenCode, Network2URL, DefaultTokenObject, TokenName } from 'types'
 
 export const code2tokenMap: Code2Name = {
   ETH: 'ETHER',
@@ -34,3 +34,10 @@ export enum ProviderName { METAMASK = 'METAMASK', MIST = 'MIST' }
 export const supportedProviders = new Set(Object.keys(ProviderName)) as Set<ProviderName>
 
 export const ETH_ADDRESS = '0x0'
+
+export const EMPTY_TOKEN: DefaultTokenObject = {
+  name: '' as TokenName,
+  symbol: '' as TokenCode,
+  decimals: 18,
+  address: '',
+}

--- a/src/globals/index.ts
+++ b/src/globals/index.ts
@@ -2,6 +2,7 @@ import { Code2Name, TokenCode, Network2URL } from 'types'
 
 export const code2tokenMap: Code2Name = {
   ETH: 'ETHER',
+  WETH: 'WRAPPED ETHER',
   GNO: 'GNOSIS',
   OWL: 'OWL',
   MGN: 'MAGNOLIA',

--- a/src/reducers/tokenPair.ts
+++ b/src/reducers/tokenPair.ts
@@ -2,6 +2,7 @@ import { handleActions } from 'redux-actions'
 
 import { selectTokenAndCloseOverlay, selectTokenPair, setSellTokenAmount, swapTokensInAPair, setClosingPrice } from 'actions'
 import { TokenPair, DefaultTokenObject, TokenMod } from 'types'
+import { ETH_ADDRESS } from 'globals'
 
 export default handleActions<
 TokenPair,
@@ -39,7 +40,8 @@ TokenPair & { token: DefaultTokenObject, mod: TokenMod, price: string }
       name: 'ETHER',
       symbol: 'ETH',
       decimals: 18,
-      address: undefined,
+      address: ETH_ADDRESS,
+      isETH: true,
     },
     buy: {
       name: 'GNOSIS',

--- a/src/selectors/index.ts
+++ b/src/selectors/index.ts
@@ -1,0 +1,3 @@
+export * from './blockchain'
+export * from './ratioPairs'
+export * from './tokens'

--- a/src/selectors/tokens.ts
+++ b/src/selectors/tokens.ts
@@ -1,18 +1,19 @@
 import { DefaultTokenObject, State } from 'types'
 import { ETH_ADDRESS } from 'globals'
 import { toBigNumber } from 'web3/lib/utils/utils.js'
+import { EMPTY_TOKEN } from 'globals'
 
 export const getTokenName = ({ symbol, name, address, isETH }: DefaultTokenObject) => {
   if (address === ETH_ADDRESS && isETH) return 'WETH'
   return symbol && symbol.toUpperCase() || name && name.toUpperCase() || address
 }
 
-export const getSellTokenBalance = ({ tokenPair: { sell }, tokenBalances }: State) => {
+export const getSellTokenBalance = ({ tokenPair: { sell = EMPTY_TOKEN }, tokenBalances }: State) => {
   const { [sell.address]: sellTokenBalance } = tokenBalances
   return sellTokenBalance === undefined ? toBigNumber(0) : sellTokenBalance
 }
 
-export const getBuyTokenBalance = ({ tokenPair: { buy }, tokenBalances }: State) => {
+export const getBuyTokenBalance = ({ tokenPair: { buy = EMPTY_TOKEN }, tokenBalances }: State) => {
   const { [buy.address]: buyTokenBalance } = tokenBalances
   return buyTokenBalance === undefined ? toBigNumber(0) : buyTokenBalance
 }

--- a/src/selectors/tokens.ts
+++ b/src/selectors/tokens.ts
@@ -1,7 +1,18 @@
-import { DefaultTokenObject } from 'types'
+import { DefaultTokenObject, State } from 'types'
 import { ETH_ADDRESS } from 'globals'
+import { toBigNumber } from 'web3/lib/utils/utils.js'
 
 export const getTokenName = ({ symbol, name, address, isETH }: DefaultTokenObject) => {
   if (address === ETH_ADDRESS && isETH) return 'WETH'
   return symbol && symbol.toUpperCase() || name && name.toUpperCase() || address
+}
+
+export const getSellTokenBalance = ({ tokenPair: { sell }, tokenBalances }: State) => {
+  const { [sell.address]: sellTokenBalance } = tokenBalances
+  return sellTokenBalance === undefined ? toBigNumber(0) : sellTokenBalance
+}
+
+export const getBuyTokenBalance = ({ tokenPair: { buy }, tokenBalances }: State) => {
+  const { [buy.address]: buyTokenBalance } = tokenBalances
+  return buyTokenBalance === undefined ? toBigNumber(0) : buyTokenBalance
 }

--- a/src/selectors/tokens.ts
+++ b/src/selectors/tokens.ts
@@ -1,7 +1,7 @@
 import { DefaultTokenObject } from 'types'
 import { ETH_ADDRESS } from 'globals'
 
-export const getTokenName = ({ symbol, name, address }: DefaultTokenObject) => {
-  if (address === ETH_ADDRESS) return 'WETH'
+export const getTokenName = ({ symbol, name, address, isETH }: DefaultTokenObject) => {
+  if (address === ETH_ADDRESS && isETH) return 'WETH'
   return symbol && symbol.toUpperCase() || name && name.toUpperCase() || address
 }

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -6,6 +6,7 @@ import { ProviderName } from 'globals'
 
 export interface Code2Name {
   ETH: 'ETHER',
+  WETH: 'WRAPPED ETHER',
   GNO: 'GNOSIS',
   REP: 'AUGUR',
   '1ST': 'FIRST BLOOD',


### PR DESCRIPTION
Fixes breaking when page is refreshed at `/order` path

- adds `getSellTokenBalance` selector that defaults to 0 in case token hasn't been fetched or selected
- adds `EMPTY_TOKEN` global var to default to to avoid many `can't get * of undefined`
- on `/order` panel hides closing price and MGN message when no token is selected (initial state)
- disables amount selling input when sell token isn't selected (initial state swapped)
- blocks going forward with sell order when one token isn't selected