### PR TITLE
Fix/stackOver of MenuAuction's hovers and TokenList

### DIFF
--- a/src/styles/components/home/_home.scss
+++ b/src/styles/components/home/_home.scss
@@ -550,7 +550,7 @@
   width: 100%;
   height: 100%;
   background: $white;
-  z-index: 10;
+  z-index: 99;
 
   @media #{$tablet} {
     position: fixed;


### PR DESCRIPTION
`.menuOrder` and `.menuAuctions` were higher in stack than `.tokenOverlay`.
Caused 
![localhost_5000_](https://user-images.githubusercontent.com/5121491/41855996-b28928d8-789c-11e8-8ce1-48f2ae3d581a.png)

Not anymore.