### PR TITLE
Fix/wallet page flash

### DIFF
--- a/src/actions/blockchain.ts
+++ b/src/actions/blockchain.ts
@@ -402,12 +402,12 @@ export const submitSellOrder = () => async (dispatch: any, getState: () => State
   
     console.log(`Sell order went to ${sellName}-${buyName}-${auctionIndex.toString()}`)
     dispatch(closeModal())
+    // jump to Auction Page
+    dispatch(push(`auction/${sellName}-${buyName}-${auctionIndex.toString()}`))
 
     // grab balance of sold token after sale
     const balance = await getTokenBalance(sell.address, currentAccount)
 
-    // jump to Auction Page
-    dispatch(push(`auction/${sellName}-${buyName}-${auctionIndex.toString()}`))
     // dispatch Actions
     dispatch(batchActions([
       setTokenBalance({ address: sell.address, balance }),


### PR DESCRIPTION
When postSellOrder modal is closing we don't immediately go to the `auction/*` path, only after refetching balance. So `/wallet` panel is shown for a second.
This goes to the `auction/*` path right away.