### PR TITLE
Feature/theor closed

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,10 @@
     "storybook": "start-storybook -s ./ -p 6006",
     "build-storybook": "build-storybook",
     "add2ipfs": "node ./scripts/add2ipfs.js",
-    "simulateAuction": "cd ./node_modules/@gnosis.pm/dx-contracts && truffle exec test/trufflescripts/add_token_pair.js --pair eth,gno && truffle exec test/trufflescripts/deposit.js -a '0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1' --gno 20000e18 && truffle exec test/trufflescripts/increase_time.js -h 8 && truffle exec test/trufflescripts/buy_order.js -a '0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1' -n 100e18 && truffle exec test/trufflescripts/increase_time.js -h 1"
+    "simulateAuction": "cd ./node_modules/@gnosis.pm/dx-contracts && truffle exec test/trufflescripts/add_token_pair.js --pair eth,gno && truffle exec test/trufflescripts/deposit.js -a '0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1' --gno 20000e18 && truffle exec test/trufflescripts/increase_time.js -h 8 && truffle exec test/trufflescripts/buy_order.js -a '0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1' -n 100e18 && truffle exec test/trufflescripts/increase_time.js -h 1",
+    "simulateTheoreticallyClosedAuction": "cd ./node_modules/@gnosis.pm/dx-contracts && truffle exec test/trufflescripts/add_token_pair.js --pair eth,gno && truffle exec test/trufflescripts/deposit.js -a '0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1' --gno 20000e18 && truffle exec test/trufflescripts/increase_time.js -h 50 && truffle exec test/trufflescripts/increase_time.js -h 1",
+    "simulateTheoreticallyClosedAuctionWithBuyVolume": "cd ./node_modules/@gnosis.pm/dx-contracts && truffle exec test/trufflescripts/add_token_pair.js --pair eth,gno && truffle exec test/trufflescripts/deposit.js -a '0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1' --gno 20000e18 && truffle exec test/trufflescripts/increase_time.js -h 8 && truffle exec test/trufflescripts/buy_order.js -a '0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1' -n 1e17 && truffle exec test/trufflescripts/increase_time.js -h 50"
+
   },
   "lint-staged": {
     "@(src|test)/**/*.js?(x)": [

--- a/src/components/AuctionPanel/index.tsx
+++ b/src/components/AuctionPanel/index.tsx
@@ -33,6 +33,7 @@ const AuctionPanel: React.SFC<AuctionPanelProps> = ({
   progress,
   error,
   claimSellerFunds,
+  theoreticallyCompleted,
 }) => (
   <AuctionContainer auctionDataScreen="status">
     <AuctionHeader backTo="/wallet">
@@ -53,6 +54,7 @@ const AuctionPanel: React.SFC<AuctionPanelProps> = ({
             timeLeft={timeToCompletion}
             status={status}
             completed={completed}
+            theoreticallyCompleted={theoreticallyCompleted}
             claimSellerFunds={claimSellerFunds}
           />
           <AuctionProgress

--- a/src/components/AuctionStateHOC/index.tsx
+++ b/src/components/AuctionStateHOC/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { TokenCode, TokenName, Account, DefaultTokenObject } from 'types'
+import { TokenCode, TokenName, Account, DefaultTokenObject, TokenPair } from 'types'
 import { BigNumber } from 'bignumber.js'
 import { AuctionStatus } from 'globals'
 // import { promisedDutchX } from 'api/dutchx'
@@ -15,7 +15,6 @@ import {
   getBuyVolume,
   getOutstandingVolume,
   getUnclaimedSellerFunds,
-  claimSellerFundsAndWithdraw,
 } from 'api'
 
 import { toBigNumber } from 'web3/lib/utils/utils.js'
@@ -35,6 +34,12 @@ export interface AuctionStateProps {
   tokenList: DefaultTokenObject[],
   address2Token: { [P in Account]: DefaultTokenObject },
   symbol2Token: { [P in TokenCode]: DefaultTokenObject },
+  claimSellerFundsAndWithdrawFromAuction(
+    pair: TokenPair,
+    index: number,
+    amount: BigNumber,
+    account: Account,
+  ): void
 }
 
 export interface AuctionStateState {
@@ -266,7 +271,7 @@ export default (Component: React.ClassType<any, any, any>): React.ClassType<any,
         `claiming tokens for ${account} for
         ${sell.symbol || sell.name || sell.address}->${buy.symbol || buy.name || buy.address}-${index}`,
       )
-      return claimSellerFundsAndWithdraw({ sell, buy }, index, amount, account)
+      return this.props.claimSellerFundsAndWithdrawFromAuction({ sell, buy }, index, amount, account)
     }
 
     render() {

--- a/src/components/AuctionStateHOC/index.tsx
+++ b/src/components/AuctionStateHOC/index.tsx
@@ -11,6 +11,9 @@ import {
   getCurrentAccount,
   getTime,
   getSellerBalance,
+  getSellVolumeCurrent,
+  getBuyVolume,
+  getOutstandingVolume,
   getUnclaimedSellerFunds,
   claimSellerFundsAndWithdraw,
 } from 'api'
@@ -36,14 +39,19 @@ export interface AuctionStateProps {
 
 export interface AuctionStateState {
   completed: boolean,
+  theoreticallyCompleted: boolean,
   status: AuctionStatus,
   sell: DefaultTokenObject,
   buy: DefaultTokenObject,
   price: number[],
+  closingPrice: number[],
   timeToCompletion: number,
   userSelling: BigNumber,
   userGetting:  BigNumber,
   userCanClaim: BigNumber,
+  sellVolume: BigNumber,
+  buyVolume: BigNumber,
+  outstandingVolume: BigNumber,
   progress: number,
   index: number,
   account: Account,
@@ -57,6 +65,7 @@ interface AuctionStatusArgs {
   auctionStart: BigNumber,
   now: number,
   price: [BigNumber, BigNumber],
+  outstandingVolume: BigNumber,
 }
 
 const getAuctionStatus = ({
@@ -65,18 +74,25 @@ const getAuctionStatus = ({
   currentAuctionIndex,
   auctionStart,
   price,
+  outstandingVolume,
 }: AuctionStatusArgs) => {
   console.log('closingPrice: ', closingPrice.map(n => n.toNumber()))
   console.log('index: ', index)
   console.log('currentAuctionIndex: ', currentAuctionIndex.toNumber())
   console.log('auctionStart: ', auctionStart.toNumber())
   console.log('price: ', price.map(n => n.toNumber()))
-  if (closingPrice[1].gt(0) || currentAuctionIndex.greaterThan(index)) return AuctionStatus.ENDED
+  if (closingPrice[1].gt(0) || currentAuctionIndex.gt(index)) return { status: AuctionStatus.ENDED }
+  // this should show theoretically auctions as ENDED and allow to claim,
+  // which internally closes the auction with a 0 buy order
+  if (currentAuctionIndex.equals(index) && closingPrice[0].equals(0) && outstandingVolume.eq(0)) {
+    console.log('Theoretically closed')
+    return { status: AuctionStatus.ENDED, theoretically: true }
+  }
   // TODO: consider if (currentAuctionIndex < index && auction has sell volume) return AuctionStatus.PLANNED
-  if (currentAuctionIndex.lessThan(index)) return AuctionStatus.PLANNED
-  if (auctionStart.equals(1)) return AuctionStatus.INIT
-  if (!price[1].equals(0)) return AuctionStatus.ACTIVE
-  return AuctionStatus.INACTIVE
+  if (currentAuctionIndex.lt(index)) return { status: AuctionStatus.PLANNED }
+  if (auctionStart.equals(1)) return { status: AuctionStatus.INIT }
+  if (!price[1].equals(0)) return { status: AuctionStatus.ACTIVE }
+  return { status: AuctionStatus.INACTIVE }
 }
 
 interface ProgressStepArgs {
@@ -170,20 +186,24 @@ export default (Component: React.ClassType<any, any, any>): React.ClassType<any,
       }
 
       const promisedAccount = getCurrentAccount()
-      const [closingPrice, price, auctionStart, now] = await Promise.all([
+      const [closingPrice, price, auctionStart, now, sellVolume, buyVolume] = await Promise.all([
         getClosingPrice(pair, index),
         getPrice(pair, index),
         getAuctionStart(pair),
         getTime(),
+        getSellVolumeCurrent(pair),
+        getBuyVolume(pair),
       ])
+      const outstandingVolume = await getOutstandingVolume(pair, { price, sellVolume, buyVolume, auctionIndex: index })
 
-      const status = getAuctionStatus({
+      const { status, theoretically } = getAuctionStatus({
         closingPrice,
         price,
         auctionStart,
         now,
         index,
         currentAuctionIndex,
+        outstandingVolume,
       })
       console.log('status: ', status)
 
@@ -196,8 +216,11 @@ export default (Component: React.ClassType<any, any, any>): React.ClassType<any,
       // as price calculation returns a slightly larger figure than buyerVolume even (price is too optimistic)
       const userGetting = sellerBalance.mul(price[0]).div(price[1])
 
-      const userCanClaim = sellerBalance.greaterThan(0) && closingPrice[0].greaterThan(0) ?
+      let userCanClaim = sellerBalance.greaterThan(0) && closingPrice[0].gte(0) ?
         (await getUnclaimedSellerFunds(pair, index, account)) : toBigNumber(0)
+      
+        // if theoretically closed, then calculate differently as fraction of current volume
+      if (theoretically) userCanClaim = buyVolume.div(sellVolume).mul(sellerBalance)
 
       const timeToCompletion = status === AuctionStatus.ACTIVE ? auctionStart.plus(86400 - now).mul(1000).toNumber() : 0
 
@@ -208,14 +231,19 @@ export default (Component: React.ClassType<any, any, any>): React.ClassType<any,
 
       this.setState({
         completed: status === AuctionStatus.ENDED,
+        theoreticallyCompleted: theoretically,
         status,
         sell: pair.sell,
         buy: pair.buy,
         price: price.map(n => n.toNumber()),
+        closingPrice: closingPrice.map(n => n.toNumber()),
         timeToCompletion,
         userSelling: sellerBalance,
         userGetting,
         userCanClaim,
+        sellVolume,
+        buyVolume,
+        outstandingVolume,
         progress,
         index,
         account,
@@ -230,13 +258,15 @@ export default (Component: React.ClassType<any, any, any>): React.ClassType<any,
     }
 
     claimSellerFunds = () => {
-      const { sell, buy, index, account, userCanClaim } = this.state
+      const { sell, buy, index, account, userCanClaim, theoreticallyCompleted } = this.state
+      //  withdraw reverts if amount < 0
+      const amount = theoreticallyCompleted && userCanClaim.eq(0) ? userCanClaim.add(1) : userCanClaim
       
       console.log(
         `claiming tokens for ${account} for
         ${sell.symbol || sell.name || sell.address}->${buy.symbol || buy.name || buy.address}-${index}`,
       )
-      return claimSellerFundsAndWithdraw({ sell, buy }, index, userCanClaim, account)
+      return claimSellerFundsAndWithdraw({ sell, buy }, index, amount, account)
     }
 
     render() {

--- a/src/components/AuctionStatus/index.tsx
+++ b/src/components/AuctionStatus/index.tsx
@@ -14,6 +14,7 @@ export interface AuctionStatusProps {
   timeLeft: number,
   status: Status,
   completed: boolean,
+  theoreticallyCompleted: boolean,
   claimSellerFunds: () => any,
 }
 

--- a/src/components/AuctionStatus/index.tsx
+++ b/src/components/AuctionStatus/index.tsx
@@ -49,7 +49,7 @@ const ShowStatus: React.SFC<AuctionStatusProps & TokenClaimingState & { claimTok
 }) => {
   switch (status) {
     case Status.ENDED:
-      if (sellAmount.eq(0)) { return (
+      if (sellAmount.eq(0) || buyAmount.eq(0)) { return (
         <span>
           <big>No funds to claim</big>
         </span>

--- a/src/components/TokenClaimingHOC/index.tsx
+++ b/src/components/TokenClaimingHOC/index.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 export interface TokenClaimingProps {
   completed: boolean,
+  theoreticallyCompleted: boolean,
   buyAmount: number,
   claimSellerFunds: () => any,
 }
@@ -22,11 +23,12 @@ export default (Component: React.ClassType<any, any, any>): React.ClassType<Toke
     async claimTokens() {
       const {
         completed,
+        theoreticallyCompleted,
         buyAmount,
         claimSellerFunds,
       } = this.props
       // don't claim anything if auction isn't completed or nothing to claim
-      if (!completed || buyAmount <= 0) return
+      if (!completed || (!theoreticallyCompleted && buyAmount <= 0)) return
 
       // indicate that claiming is in progress
       // can be used to disallow multiple simultaneous claimRequests or just for indication

--- a/src/containers/AuctionPanel/index.ts
+++ b/src/containers/AuctionPanel/index.ts
@@ -3,6 +3,7 @@ import AuctionPanel from 'components/AuctionPanel'
 import { State } from 'types'
 import AuctionStateHOC from 'components/AuctionStateHOC'
 import { createSelector } from 'reselect'
+import { claimSellerFundsAndWithdrawFromAuction } from 'actions'
 
 const makeSets = createSelector(
   ({ tokenList }) => tokenList.type !== 'DEFAULT' ? tokenList.combinedTokenList : tokenList.defaultTokenList,
@@ -25,4 +26,4 @@ const mapStateToProps = (state: State) => ({
 })
 
 
-export default connect(mapStateToProps)(AuctionStateHOC(AuctionPanel))
+export default connect(mapStateToProps, { claimSellerFundsAndWithdrawFromAuction })(AuctionStateHOC(AuctionPanel))

--- a/stories/AuctionContainer.tsx
+++ b/stories/AuctionContainer.tsx
@@ -100,6 +100,7 @@ storiesOf('AuctionContainer', module)
           step: 5,
         })}
         completed={boolean('comleted', true)}
+        theoreticallyCompleted={boolean('comleted', true)}
         claimSellerFunds={() => {}}
       />
       <AuctionProgress progress={4} marks={[true, true, true]} />


### PR DESCRIPTION
A workaround to be able to claim/unstuck theoretically closed auctions

Like this:


1. - Consider them `AuctionStatus.ENDED`
2. - Allow to `claimAndWithdraw` from Auction panel
3. - If `buyVolume` is 0 and price over time went to 0, the user unstucks the auction but his sellerBalance (WETH in WETH->OMG for example) isn't automatically withdrawn as it's not a buy token, so it's stuck inside `DX.balances`

Does not address theoretica auctions in `Header > Your Auctions`