### PR TITLE
Feature/listen for network change

### DIFF
--- a/src/api/apiTesting.ts
+++ b/src/api/apiTesting.ts
@@ -7,57 +7,12 @@ export default async () => {
   const {
     TokenETH,
     TokenGNO,
-    TokenOMG,
-    TokenRDN,
     TokenMGN,
+    // TokenOMG,
+    // TokenRDN,
   } = await promisedContractsMap
 
   // TODO: hard-code actual addresses here
-  if (process.env.NODE_ENV === 'development') {
-    return {
-      elements: [
-        {
-          name: 'ETHER',
-          symbol: 'ETH',
-          address: ETH_ADDRESS,
-          isETH: true,
-          decimals: 18,
-        },
-        {
-          name: 'WRAPPED ETHER',
-          symbol: 'WETH',
-          address: TokenETH.address,
-          decimals: (await TokenETH.decimals()).toNumber(),
-        },
-        {
-          name: 'GNOSIS TOKEN',
-          symbol: 'GNO',
-          address: TokenGNO.address,
-          decimals: (await TokenGNO.decimals()).toNumber(),
-        },
-        {
-          name: 'OMISEGO',
-          symbol: 'OMG',
-          address: TokenOMG.address,
-          decimals: TokenOMG.decimals ? (await TokenOMG.decimals()).toNumber() : 12,
-        },
-        {
-          name: 'RAIDEN',
-          symbol: 'RDN',
-          address: TokenRDN.address,
-          decimals: TokenRDN.decimals ? (await TokenRDN.decimals()).toNumber() : 6,
-        },
-        {
-          name: 'MAGNOLIA',
-          symbol: 'MGN',
-          address: TokenMGN.address,
-          decimals: 18,
-        },
-      ],
-      page: 1,
-      hasMorePages: false,
-    } as DefaultTokens
-  }
   return {
     elements: [
       {
@@ -85,6 +40,18 @@ export default async () => {
         address: TokenMGN.address,
         decimals: 18,
       },
+      // {
+      //   name: 'OMISEGO',
+      //   symbol: 'OMG',
+      //   address: TokenOMG.address,
+      //   decimals: TokenOMG.decimals ? (await TokenOMG.decimals()).toNumber() : 12,
+      // },
+      // {
+      //   name: 'RAIDEN',
+      //   symbol: 'RDN',
+      //   address: TokenRDN.address,
+      //   decimals: TokenRDN.decimals ? (await TokenRDN.decimals()).toNumber() : 6,
+      // },
     ],
     page: 1,
     hasMorePages: false,

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -15,7 +15,7 @@ import ModalContainer from 'containers/Modals'
 import { asyncLoadSettings } from 'actions'
 
 export const history = createHistory()
-const store = createStoreWithHistory(history)
+export const store = createStoreWithHistory(history)
 
 // load data from localstorage
 store.dispatch({ type: 'INIT' })

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -1,10 +1,16 @@
 import React from 'react'
+import appInfo from '../../../package.json'
+
 // TODO: add content for footer
 const Footer = () =>
     <footer>
         <p>
             Trading on DutchX carries a risk to your capital. Please read our full <a href="#">Risk Disclaimer</a>, <a href="#">Privacy Policy</a> and <a href="#">Terms of Service</a> before trading. – <a href="#">Imprint</a>
         </p>
+        <div>
+          <i>DX-React: {appInfo.version}</i>
+          <i>DX-Contracts: {appInfo.dependencies['@gnosis.pm/dx-contracts']}</i>
+        </div>
     </footer>
 
 export default Footer

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,6 +8,9 @@ import App, { initializer, loadSettings } from 'components/App'
 
 import blocked_codes from './blocked_codes.json'
 
+// run Event Listeners from events.ts
+import 'integrations/events'
+
 // set last () => any on Array prototype
 Array.prototype.last = function getLast() {
   return this[this.length - 1]
@@ -30,7 +33,7 @@ const geoBlockedCountryCodes = new Set(blocked_codes)
 const isGeoBlocked = async () => {
   try {
     const res = await fetch('https://geoip.gnosis.pm/json/')
-    
+
     // this DOES NOT block even if the URL above starts returning 404
     if (!res.ok) return false
 
@@ -39,7 +42,7 @@ const isGeoBlocked = async () => {
     return geoBlockedCountryCodes.has(country_code)
   } catch (error) {
     console.error(error)
-    
+
     // this does NOT block if there is a network error, e.g. URL is blocked
     return false
   }

--- a/src/integrations/events.ts
+++ b/src/integrations/events.ts
@@ -1,0 +1,45 @@
+import { watch, getBlock } from 'integrations/filterChain'
+import localForage from 'localforage'
+import { promisedWeb3 } from 'api/web3Provider'
+import { store } from 'components/App'
+
+// ========== //
+// scope vars //
+// ========== //
+
+let netID: string
+
+// =============== //
+// event listeners //
+// =============== //
+
+const fireListeners = async () => {
+  console.log('FIRING LISTENERS')
+
+  const { web3  } = await promisedWeb3
+  web3.currentProvider.publicConfigStore.on('update', async ({ selectedAddress, networkVersion }: any) => {
+
+    if (selectedAddress === store.getState().blockchain.currentAccount && netID === networkVersion) return
+
+    console.log(`
+    ==> 1: Network watcher fired, detected network change
+      L.Net.ID  ${netID}
+      C.Net.ID: ${networkVersion}
+    `)
+    // alert(`networkVersions: ${networkVersion} ${netID}`)
+    if (!netID || netID !== networkVersion) {
+      netID = networkVersion
+      await localForage.removeItem('defaultTokens')
+    }
+  })
+
+  // TEMP SAMPLE USAGE
+  watch(async (e, bl) => {
+    console.log(' ==> 2: Block watcher fired')
+    if (e) return console.error('Chain watching Error', e)
+    console.log('LATEST BLOCK')
+    console.log(await getBlock(bl))
+  })
+}
+
+fireListeners()

--- a/src/integrations/initialize.ts
+++ b/src/integrations/initialize.ts
@@ -8,9 +8,7 @@ import MetamaskProvider from './metamask'
 import ParityProvider from './parity'
 import RemoteProvider from './remote'
 
-import { watch, getBlock } from './filterChain'
-
-export const WATCHER_INTERVAL = 6000
+export const WATCHER_INTERVAL = 5000
 
 const networkById = {
   1: ETHEREUM_NETWORKS.MAIN,
@@ -76,7 +74,7 @@ export default async ({ registerProvider, updateProvider, updateMainAppState, re
         available = provider.walletAvailable,
         unlocked = !!(available && account),
         newState = { account, network, balance, available, unlocked, timestamp }
-        
+
         // if data changed
       if (shallowDifferent(provider.state, newState)) {
         console.log('app state is different')
@@ -114,12 +112,5 @@ export default async ({ registerProvider, updateProvider, updateMainAppState, re
     watcher(provider)
     // regularly refetch state
     setInterval(() => watcher(provider), WATCHER_INTERVAL)
-  })
-
-  // TEMP SAMPLE USAGE
-  watch(async (e, bl) => {
-    if (e) return console.error('Chain watching Error', e)
-    console.log('LATEST BLOCK')
-    console.log(await getBlock(bl))
   })
 }

--- a/src/integrations/initialize.ts
+++ b/src/integrations/initialize.ts
@@ -5,8 +5,8 @@ import { WalletProvider, ConnectedInterface } from './types'
 import { Account, Balance } from 'types'
 
 import MetamaskProvider from './metamask'
-import ParityProvider from './parity'
-import RemoteProvider from './remote'
+// import ParityProvider from './parity'
+// import RemoteProvider from './remote'
 
 export const WATCHER_INTERVAL = 5000
 
@@ -20,8 +20,8 @@ const networkById = {
 
 const providers: WalletProvider[] = [
   MetamaskProvider,
-  ParityProvider,
-  RemoteProvider,
+  // ParityProvider,
+  // RemoteProvider,
 ]
 
 // compare object properties
@@ -37,9 +37,8 @@ const shallowDifferent = (obj1: object, obj2: object) => {
 }
 
 // Fired from WalletIntegrations as part of the React mounting CB in src/index.ts
-export default async ({ registerProvider, updateProvider, updateMainAppState, resetMainAppState }: ConnectedInterface | any) => {
+export default ({ registerProvider, updateProvider, updateMainAppState, resetMainAppState }: ConnectedInterface | any) => {
   let prevTime: number
-
   const getAccount = async (provider: WalletProvider): Promise<Account> => {
     const [account] = await promisify(provider.web3.eth.getAccounts, provider.web3.eth)()
 
@@ -59,7 +58,7 @@ export default async ({ registerProvider, updateProvider, updateMainAppState, re
   }
 
   // Fired on setInterval every 10 seconds
-  const watcher = async (provider: WalletProvider) => {
+  const watcher = async (provider: WalletProvider, init?: string | boolean) => {
     if (!provider.checkAvailability()) return
 
     // set block timestamp to provider state and compare
@@ -84,7 +83,7 @@ export default async ({ registerProvider, updateProvider, updateMainAppState, re
         prevTime = timestamp
         // dispatch action with updated provider state
         updateProvider(provider.providerName, provider.state = newState)
-        await updateMainAppState()
+        init ? console.log('Provider INIT - not updating state') : await updateMainAppState()
       }
     } catch (err) {
       console.warn(err)
@@ -106,10 +105,10 @@ export default async ({ registerProvider, updateProvider, updateMainAppState, re
     // each provider intializes by creating its own web3 instance if there is a corresponding currentProvider injected
     provider.initialize()
     if (!provider.walletAvailable) return
-    // dispatch action to save provider name and proirity
+    // dispatch action to save provider name and priority
     registerProvider(provider.providerName, { priority: provider.priority })
-    // get account, balance, etc. state
-    watcher(provider)
+    // get account, balance, etc. PROVIDER state - do not update main app state yet
+    watcher(provider, 'init')
     // regularly refetch state
     setInterval(() => watcher(provider), WATCHER_INTERVAL)
   })

--- a/src/integrations/walletIntegration.ts
+++ b/src/integrations/walletIntegration.ts
@@ -128,6 +128,9 @@ export default async function walletIntegration(store: Store<any>) {
   }
 
   try {
+    // init Provider first - set a watcher for 6000 ms to check changes
+    initialize(providerOptions)
+
     const { combinedTokenList } = await dispatch(getTokenList())
 
     // TODO: fetch approvedTokens list from api
@@ -143,7 +146,6 @@ export default async function walletIntegration(store: Store<any>) {
     dispatch(setApprovedTokens(approvedTokenAddresses))
     dispatch(setAvailableAuctions(availableAuctions))
 
-    await initialize(providerOptions)
   } catch (error) {
     console.warn('Error in walletIntegrations: ', error.message || error)
   } finally {

--- a/src/integrations/walletIntegration.ts
+++ b/src/integrations/walletIntegration.ts
@@ -22,13 +22,15 @@ import { checkTokenListJSON } from 'api/utils'
 import { getAllTokenDecimals, getApprovedTokensFromAllTokens, getAvailableAuctionsFromAllTokens } from 'api'
 
 import { DefaultTokens, DefaultTokenObject } from 'api/types'
-// import tokensMap from 'api/apiTesting'
+import tokensMap from 'api/apiTesting'
 
 import { State } from 'types'
 import { ConnectedInterface } from './types'
-import { IPFS_TOKENS_HASH } from 'globals'
+import { ETHEREUM_NETWORKS } from './constants'
+// import { IPFS_TOKENS_HASH } from 'globals'
 
-export const getTokenList = async (dispatch: Dispatch<any>, getState: () => State) => {
+export const getTokenList = (network?: string) => async (dispatch: Dispatch<any>, getState: () => State) => {
+
   let [defaultTokens, customTokens, customListHash] = await Promise.all<DefaultTokens, DefaultTokens['elements'], string>([
     localForage.getItem('defaultTokens'),
     localForage.getItem('customTokens'),
@@ -38,15 +40,43 @@ export const getTokenList = async (dispatch: Dispatch<any>, getState: () => Stat
   const isDefaultTokensAvailable = !!(defaultTokens)
 
   if (!isDefaultTokensAvailable) {
+    network = network || window.web3.version.network
+
+    console.log('Current Network =', network)
+
     // grab tokens from IPFSHash or api/apiTesting depending on NODE_ENV
-    if (process.env.NODE_ENV === 'development') {
+    /* if (process.env.NODE_ENV === 'development') {
       defaultTokens = await ipfsFetchFromHash(IPFS_TOKENS_HASH) as DefaultTokens
     } else {
       // TODO: change for prod
       defaultTokens = await ipfsFetchFromHash(IPFS_TOKENS_HASH) as DefaultTokens
+    } */
+
+    switch (network) {
+      case '4' || ETHEREUM_NETWORKS.RINKEBY:
+        console.log(`Detected connection to ${ETHEREUM_NETWORKS.RINKEBY}`)
+        defaultTokens = require('../../test/resources/token-lists/RINKEBY/token-list.js')
+        console.log('Rinkeby Token List -> ', defaultTokens.elements)
+        break
+
+      case '1' || ETHEREUM_NETWORKS.MAIN:
+        console.log(`Detected connection to ${ETHEREUM_NETWORKS.MAIN}`)
+        // TODO: fix for Mainnet
+        defaultTokens = require('../../test/resources/token-lists/MAIN/token-list.js')
+        console.warn(`
+          Ethereum Mainnet not supported - please try another network.
+          Removing tokens from localForage ...
+          ${defaultTokens.elements}
+        `)
+        break
+
+      default:
+        console.log(`Detected connection to an UNKNOWN network -- localhost?`)
+        defaultTokens = await tokensMap()
+        console.log('LocalHost Token List -> ', defaultTokens.elements)
+        break
     }
 
-    console.log('​getTokenList -> ', defaultTokens)
     // set tokens to localForage
     await localForage.setItem('defaultTokens', defaultTokens)
   }
@@ -98,7 +128,7 @@ export default async function walletIntegration(store: Store<any>) {
   }
 
   try {
-    const { combinedTokenList } = await getTokenList(dispatch, getState)
+    const { combinedTokenList } = await dispatch(getTokenList())
 
     // TODO: fetch approvedTokens list from api
     // then after getting tokensJSON in getDefaultTokens create a list of approved TokenCodes

--- a/src/middlewares/NetworkChange.ts
+++ b/src/middlewares/NetworkChange.ts
@@ -1,0 +1,33 @@
+import { Middleware, Action } from 'redux'
+import { ThunkAction } from 'redux-thunk'
+import { State } from 'types'
+import { Dispatch } from 'react-redux'
+
+// import localForage from 'localforage'
+import { code2Network } from 'utils/helpers'
+
+// const LOAD_LOCALSTORAGE = 'LOAD_LOCALSTORAGE'
+
+const NetworkChange: Middleware = ({ getState }: { dispatch: Dispatch<any>, getState: any }) => next => async (action: Action | ThunkAction<Action, Partial<State>, void>) => {
+  const { type } = action as Action
+
+  if (type !== 'UPDATE_PROVIDER') return next(action as Action)
+
+  // @ts-ignore
+  const { network: payloadNetwork } = action.payload
+  const { activeProvider/* , connected */ } = getState().blockchain
+  const { network } = getState().blockchain.providers[activeProvider]
+
+  if (network === payloadNetwork || payloadNetwork === code2Network(window.web3.version.network)) return next(action as Action)
+
+  try {
+    // delete defaultTokenList
+    // MetaMask refreshes...
+    // await localForage.removeItem('defaultTokens')
+    return next(action as Action)
+  } catch (e) {
+    // Unable to load or parse stored state, proceed as usual
+  }
+}
+
+export default NetworkChange

--- a/src/middlewares/index.ts
+++ b/src/middlewares/index.ts
@@ -1,0 +1,7 @@
+import CrashReporter from './CrashReporter'
+import NetworkChange from './NetworkChange'
+
+export {
+  CrashReporter,
+  NetworkChange,
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -4,7 +4,7 @@ import { History } from 'history'
 import thunk from 'redux-thunk'
 
 import { enableBatching } from 'redux-batched-actions'
-import { CrashReporter, NetworkChange } from 'middlewares'
+import { CrashReporter/* , NetworkChange */ } from 'middlewares'
 
 import { State } from 'types'
 
@@ -15,7 +15,7 @@ export default function (history: History, initialState?: Partial<State>) {
     thunk,
     routerMiddleware(history),
     CrashReporter,
-    NetworkChange,
+    // NetworkChange,
   ]
 
   const composeEnhancers = (process.env.NODE_ENV !== 'production' &&

--- a/src/store.ts
+++ b/src/store.ts
@@ -4,7 +4,7 @@ import { History } from 'history'
 import thunk from 'redux-thunk'
 
 import { enableBatching } from 'redux-batched-actions'
-import CrashReporter from 'middlewares/CrashReporter'
+import { CrashReporter, NetworkChange } from 'middlewares'
 
 import { State } from 'types'
 
@@ -15,6 +15,7 @@ export default function (history: History, initialState?: Partial<State>) {
     thunk,
     routerMiddleware(history),
     CrashReporter,
+    NetworkChange,
   ]
 
   const composeEnhancers = (process.env.NODE_ENV !== 'production' &&

--- a/src/styles/core/_base.scss
+++ b/src/styles/core/_base.scss
@@ -108,7 +108,7 @@ footer {
   box-sizing: border-box;
   display: flex;
   background: $greyLight;
-  flex-wrap: wrap;
+  flex-flow: column wrap;
   justify-content: center;
   align-items: center;
   margin: auto auto 0;
@@ -119,5 +119,17 @@ footer {
 
   p > a {
     color: $blue;
+  }
+
+  > div {
+    display: flex;
+    flex-flow: row wrap;
+    justify-content: center;
+    align-items: center;
+
+    > i {
+      font-size: 8px;
+      padding: 0 3px;
+    }
   }
 }

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -21,6 +21,22 @@ export const getDutchXOptions = (provider: any) => {
   return opts
 }
 
+export const code2Network = (code: '1' | '4' | '42') => {
+  switch (code) {
+    case '1':
+      return 'MAIN'
+
+    case '4':
+      return 'RINKEBY'
+
+    case '42':
+      return 'KOVAN'
+
+    default:
+      return 'UNKNOWN'
+  }
+}
+
 export const timeoutCondition = (timeout: any, rejectReason: any) => new Promise((_, reject) => {
   setTimeout(() => {
     reject(rejectReason)

--- a/test/resources/token-lists/MAIN/token-list.js
+++ b/test/resources/token-lists/MAIN/token-list.js
@@ -1,0 +1,29 @@
+// npm run add2ipfs -- test/resources/token-pairs-ipfs-rinkeby.js
+
+// MAIN
+
+module.exports = {
+  elements: [
+    {
+      symbol: 'ETH',
+      name: 'Ether',
+      address: '0x0',
+      decimals: 18,
+      isETH: true,
+    },
+    {
+      symbol: 'WETH',
+      name: 'Wrapped Ether',
+      address: '0xc778417e063141139fce010982780140aa0cd5ab',
+      decimals: 18,
+    },
+  ],
+  pagination: {
+    endingBefore: null,
+    startingAfter: null,
+    limit: 20,
+    order: [{ param: 'symbol', direction: 'ASC' }],
+    previousUri: null,
+    nextUri: null,
+  },
+}

--- a/test/resources/token-lists/RINKEBY/token-list.js
+++ b/test/resources/token-lists/RINKEBY/token-list.js
@@ -1,5 +1,7 @@
 // npm run add2ipfs -- test/resources/token-pairs-ipfs-rinkeby.js
 
+// RINKEBY
+
 module.exports = {
   elements: [
     {

--- a/test/trufflescripts/add_token_pair.js
+++ b/test/trufflescripts/add_token_pair.js
@@ -83,7 +83,7 @@ module.exports = async () => {
 
   console.log('Account', accountName)
   console.log('Sell Token = ', sell, '|| BAL == ', (await dx.balances.call(sellToken.address, account)).toNumber() / (10 ** 18))
-  console.log('Buy Token = ', buy, '|| BAL == ', (await dx.balances.call(buyToken.address, account)).toNumber() / (10 ** 18))
+  console.log('Buy Token = ', buy, ' @', buyToken.address, '|| BAL == ', (await dx.balances.call(buyToken.address, account)).toNumber() / (10 ** 18))
 
   console.log('FundingUSD == ', startingETH * ethUSDPrice)
   console.log('Auction Index BEFORE == ', (await dx.getAuctionIndex.call(sellToken.address, buyToken.address)).toNumber())


### PR DESCRIPTION
# Listeners + TokenList switching

> this PR is meant to better utilise `web3` listening tools to adjust to changes in state - it uses this to switch `tokenLists` when user switches network

TODO
- [x] better test tokenList switching
- [ ] use IPFS hash links to `get` or find other way just move local tokenLists out of FS
- [ ] ... more