### PR TITLE
Contents links and other changes

### DIFF
--- a/src/actions/blockchain.ts
+++ b/src/actions/blockchain.ts
@@ -454,7 +454,7 @@ export const checkUserStateAndSell = () => async (dispatch: Dispatch<any>, getSt
             },
             footer: {
               msg: `If you are unsure, select “Approve ${sellName} for this trade only”.`,
-              url: './content/FAQ',
+              url: '#/content/FAQ',
               urlMsg: 'FAQ',
             },
             onClick: accept,
@@ -487,7 +487,7 @@ export const checkUserStateAndSell = () => async (dispatch: Dispatch<any>, getSt
                 },
               },
               footer: {
-                url: './content/Fees',
+                url: '#/content/Fees',
                 urlMsg: 'Fees',
               },
               onClick: accept,

--- a/src/actions/blockchain.ts
+++ b/src/actions/blockchain.ts
@@ -765,11 +765,7 @@ export const claimSellerFundsFromSeveral = (
     console.log('withdraw tx logs', withdrawLogs)
 
     // Find the 'NewWithdrawal' log
-    let withdrawEvents
-    // loop until sellBalance drops to 0
-    while (!withdrawEvents) {
-      withdrawEvents = withdrawLogs.find((log: Web3EventLog) => log._eventName === 'NewWithdrawal')
-    }
+    const withdrawEvents = withdrawLogs.find((log: Web3EventLog) => log._eventName === 'NewWithdrawal')
 
     console.log('>>=====> NEW_WITHDRAWAL_EVENT >>====> ', withdrawEvents)
 

--- a/src/actions/modal.ts
+++ b/src/actions/modal.ts
@@ -2,4 +2,4 @@ import { createAction } from 'redux-actions'
 import { Modal } from 'types'
 
 export const openModal = createAction<Partial<Modal>>('OPEN_MODAL')
-export const closeModal = createAction('CLOSE_MODAL')
+export const closeModal = createAction('CLOSE_MODAL', () => {})

--- a/src/actions/panelChange.ts
+++ b/src/actions/panelChange.ts
@@ -1,22 +1,4 @@
 import { createAction } from 'redux-actions'
-import { Dispatch } from 'react-redux'
-import { push } from 'connected-react-router'
-import { grabElementID } from 'containers/ContentPages'
 
 // TODO: fill payload
 export const continueToOrder = createAction<any>('CONTINUE_TO_ORDER', () => { })
-
-export const pushAndMoveToElement = (sectionID: string, outsidePage?: string) => async (dispatch: Dispatch<any>) => {
-  if (outsidePage) {
-      await dispatch(push(outsidePage))
-    }
-
-  if (!sectionID) return
-
-  if (Array.from(grabElementID(sectionID).classList).some((className: string) => className === 'active')) {
-      return grabElementID(sectionID).scrollIntoView()
-    }
-
-  grabElementID(sectionID).classList.toggle('active')
-  return grabElementID(sectionID).scrollIntoView()
-}

--- a/src/components/ContentPage/index.tsx
+++ b/src/components/ContentPage/index.tsx
@@ -12,7 +12,7 @@ export const HowItWorks = ({ handleClick }: ContentPages) => (
   <article>
     <h1>How the DutchX works</h1>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" id="dutchx-in-short" onClick={handleClick}>
       <h3>The DutchX in short</h3>
       <span>
         <p>
@@ -22,7 +22,7 @@ export const HowItWorks = ({ handleClick }: ContentPages) => (
       </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" id="what-is-dutchx" onClick={handleClick}>
       <h3>What is the DutchX exactly?</h3>
       <span>
         <p>
@@ -38,7 +38,7 @@ export const HowItWorks = ({ handleClick }: ContentPages) => (
       </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" id="how-dutch-auction-works" onClick={handleClick}>
       <h3>How does a Dutch auction work?</h3>
       <span>
         <p>
@@ -49,7 +49,7 @@ export const HowItWorks = ({ handleClick }: ContentPages) => (
       </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" id="dutchx-characteristics" onClick={handleClick}>
       <h3>What are the specific characteristics of the DutchX?</h3>
       <span>
         <p>
@@ -60,7 +60,7 @@ export const HowItWorks = ({ handleClick }: ContentPages) => (
       </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" id="how-long-auction-takes" onClick={handleClick}>
       <h3>How long does an auction take?</h3>
       <span>
         <p>
@@ -69,7 +69,7 @@ export const HowItWorks = ({ handleClick }: ContentPages) => (
       </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" id="when-do-i-claim-tokens" onClick={handleClick}>
       <h3>When do I claim my tokens?</h3>
       <span>
         <p>
@@ -93,7 +93,7 @@ export const HowItWorks = ({ handleClick }: ContentPages) => (
       </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" id="when-auctions-start" onClick={handleClick}>
       <h3>When do auctions start?</h3>
       <span>
         <p>
@@ -103,14 +103,14 @@ export const HowItWorks = ({ handleClick }: ContentPages) => (
       </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" id="when-auctions-end" onClick={handleClick}>
       <h3>When do auctions end?</h3>
       <span>
         <p>Auctions end when all deposits (<i>sellTokens</i>) have been bought and thus are allocated to bidders at the auction clearing price. The auction clearing price is the price that all <i>sellTokens</i> are traded at (i.e. <i>bidVolume</i> x price = <i>sellVolume</i>).</p>
       </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" id="which-tokens-can-trade" onClick={handleClick}>
       <h3>Which tokens can I trade?</h3>
       <span>
         <p>
@@ -132,7 +132,7 @@ export const HowItWorks = ({ handleClick }: ContentPages) => (
       </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" id="step-by-step-submit-deposit" onClick={handleClick}>
       <h3>Step-by-step guide to submit a deposit (=order):</h3>
       <span>
         <p>
@@ -171,7 +171,7 @@ export const HowItWorks = ({ handleClick }: ContentPages) => (
       </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" id="why-not-know-how-many-tokens-will-receive" onClick={handleClick}>
       <h3>Why do I not know in advance how many tokens I am receiving?</h3>
       <span>
         <p>
@@ -199,7 +199,7 @@ export const HowItWorks = ({ handleClick }: ContentPages) => (
       </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" id="hwhat-is-in-your-auctions" onClick={handleClick}>
       <h3>What is displayed in “Your Auctions”?</h3>
       <span>
         <p>You can see three statuses:</p>
@@ -228,14 +228,14 @@ export const HowItWorks = ({ handleClick }: ContentPages) => (
       </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" id="what-is-fee-level" onClick={handleClick}>
       <h3>What is my fee level?</h3>
       <span>
         <p>By default, your fee level is 0.5% of your trading volume. It taken from the deposited amount. You may lower your fees by trading frequently or holding MGN. For more info, check out the <Link to={URLS.FEES + '#fees'}>Fee</Link> section.</p>
       </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" id="what-is-wont-generate-mgn" onClick={handleClick}>
       <h3>What does “Any auction with [Token] won’t generate MGN” mean?</h3>
       <span>
         <p>This message is to inform you about whether the token you are looking to trade generates Magnolia (which is used for fee-reduction) when you trade it. Find more information on this process <Link to={URLS.TOKENS + '#what-is-mgn'}>here</Link>. You can still use the trading interface in the same manner for tokens that do and do not generate Magnolia.</p>

--- a/src/components/ContentPage/index.tsx
+++ b/src/components/ContentPage/index.tsx
@@ -6,7 +6,6 @@ import 'assets/pdf/DutchX_Rinkeby_PrivacyPolicy.pdf'
 
 interface ContentPages {
   handleClick: () => any;
-  handleSectionMove: (id: string, url?: string) => void;
 }
 
 export const HowItWorks = ({ handleClick }: ContentPages) => (

--- a/src/components/ContentPage/index.tsx
+++ b/src/components/ContentPage/index.tsx
@@ -270,7 +270,7 @@ export const Tokens = ({ handleClick }: ContentPages) =>
   <article>
     <h1>Tokens</h1>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="token-pairs-currently-traded">
       <h3>Which token pairs are currently traded on the DutchX?</h3>
       <span>
         <p>
@@ -281,7 +281,7 @@ export const Tokens = ({ handleClick }: ContentPages) =>
       </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="token-pairs-can-be-traded">
       <h3>Which token pairs can be traded on the DutchX?</h3>
       <span>
         <p>
@@ -290,7 +290,7 @@ export const Tokens = ({ handleClick }: ContentPages) =>
       </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="token-needed-to-trade">
       <h3>What token do I need to be active on the DutchX?</h3>
       <span>
       <p>
@@ -319,7 +319,7 @@ export const Tokens = ({ handleClick }: ContentPages) =>
       </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="does-trade-generate-mgn">
       <h3>Does my trade generate Magnolia?</h3>
       <span>
         <p>
@@ -328,7 +328,7 @@ export const Tokens = ({ handleClick }: ContentPages) =>
       </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="token-currently-whitelisted">
       <h3>Which tokens are currently whitelisted?</h3>
       <span>
         <p>
@@ -338,7 +338,7 @@ export const Tokens = ({ handleClick }: ContentPages) =>
       </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="how-to-whitelist-token">
       <h3>How can a token be whitelisted?</h3>
       <span>
         <p>Please read <a href={URLS.LISTING_A_TOKEN} target="_blank">Listing a Token</a>.</p>
@@ -350,14 +350,14 @@ export const Tokens = ({ handleClick }: ContentPages) =>
 export const Fees = ({ handleClick }: ContentPages) =>
   <article id="fees">
     <h1>Fees</h1>
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="what-fees-need-to-pay">
       <h3>What fees do I have to pay?</h3>
       <span>
         <p>The default fee is 0.5% of your trading volume. While this might seem high at first glance, fees can be lowered down to 0%. You may also benefit from other participants’ fees, which are kept in the DutchX ecosystem.</p>
       </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="how-to-lower-fees">
       <h3>How can I lower my fees?</h3>
       <span>
         <p>
@@ -400,14 +400,14 @@ export const Fees = ({ handleClick }: ContentPages) =>
       </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="where-to-see-fees">
       <h3>Where do I see my fees?</h3>
       <span>
         <p>In the header bar of the interface, your fee level is displayed. Note that this is a snapshot in time and due to the changing Magnolia market volume, this number should be seen as an estimate.</p>
       </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="how-to-get-mgn">
       <h3>How do I obtain Magnolia (MGN)?</h3>
       <span>
       <p>
@@ -417,14 +417,14 @@ export const Fees = ({ handleClick }: ContentPages) =>
     </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="how-to-trade-mgn">
       <h3>How do I trade Magnolia?</h3>
       <span>
       <p>To trade MGN, you must unlock them first. After a waiting period of 24 hours, they may be traded. Unlocked MGN may be locked again to immediately make use of the fee reduction model. Currently, however, this function is not yet supported by this interface but will be available in the next version.</p>
     </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="why-hold-mgn">
       <h3>Why is it beneficial to hold a lot of Magnolia?</h3>
       <span>
         <p>
@@ -445,7 +445,7 @@ export const Fees = ({ handleClick }: ContentPages) =>
       </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="what-to-use-owl-for">
       <h3>What are OWL used for on the DutchX?</h3>
       <span>
         <p>
@@ -454,7 +454,7 @@ export const Fees = ({ handleClick }: ContentPages) =>
       </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="how-much-is-owl-worth">
       <h3>How much is OWL worth?</h3>
       <span>
         <p>
@@ -464,14 +464,14 @@ export const Fees = ({ handleClick }: ContentPages) =>
       </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="why-pay-fees-in-owl">
       <h3>Why would I want to pay my fees in OWL?</h3>
       <span>
         <p>Firstly, if you are a GNO holder, you obtain OWL by locking your GNO. Secondly, one OWL can be used to pay one USD worth of fees (this is fixed on the DutchX). Thirdly, it is likely cheaper as the OWL may be obtained for less than one USD.</p>
       </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="how-to-pay-fees-in-owl">
       <h3>How do I use OWL to pay for fees?</h3>
       <span>
         <p>
@@ -481,7 +481,7 @@ export const Fees = ({ handleClick }: ContentPages) =>
       </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="what-happens-to-owl-used-for-fees">
       <h3>What happens to the OWL used to pay for fees?</h3>
       <span>
         <p>
@@ -490,7 +490,7 @@ export const Fees = ({ handleClick }: ContentPages) =>
       </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="how-to-pay-fees">
       <h3>How do I pay my fees?</h3>
       <span>
         <p>
@@ -499,7 +499,7 @@ export const Fees = ({ handleClick }: ContentPages) =>
       </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="fee-calculation">
       <h3>Step-by-step fee calculation</h3>
       <span>
         <p>Imagine you are taking part with a volume of 20 Token A.</p>
@@ -526,28 +526,28 @@ export const Fees = ({ handleClick }: ContentPages) =>
     </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="what-happens-to-fees-paid-in-a-token">
       <h3>What happens to fees paid in a token (not in OWL)?</h3>
       <span>
       <p>These fees remain in the DutchX ecosystem and are redistributed among participants (mainly high-volume users will benefit from this fee redistribution model). Fees will <span className="underline">go into the next running auction</span> for the same token pair as an extra deposit-balance.</p>
     </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="why-fees-go-into-next-auction">
       <h3>What is the reasoning for the fees to go into the next auction?</h3>
       <span>
       <p>Users of the DutchX should be the main beneficiaries of this decentralized trading protocol. Hence, the fees should remain in the DutchX ecosystem. This means that users, and especially frequent users, benefit as they not only lower their fees, but get credited part of the fees!</p>
     </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="how-are-owls-burned">
       <h3>How are OWLs burned?</h3>
       <span>
       <p>Burning OWL means that they will be collected in a smart contract that cannot be accessed by anyone.</p>
     </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="do-i-have-to-pay-for-gas">
       <h3>Do I also have to pay a gas price?</h3>
       <span>
         <p>Yes, you do! For all transactions on the Ethereum blockchain, gas has to be paid. The amount of gas cost to be paid depends on the current transactions being processed on Ethereum. Gas is needed to execute your order and claim your new tokens. Your wallet provider will provide you with a gas estimate for each transaction, and you may set a gas price.</p>
@@ -559,7 +559,7 @@ export const Fees = ({ handleClick }: ContentPages) =>
 export const AuctionMechanisms = ({ handleClick }: ContentPages) =>
   <article>
     <h1>Auction Mechanisms</h1>
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="dutchx">
       <h3>DutchX</h3>
       <span>
       <p>The DutchX is a decentralized exchange for ERC20 token pairings, based on the Dutch auction principle. Taking the traditional order book model to the blockchain makes little sense: problems such as front-running are magnified in discrete time. The mechanism of the DutchX is designed such that sellers submit their tokens ahead of an auction. Then, the auction starts with a high price which falls until the market for the specific token-pairing clears. Bidders submit their bids during the auction, but pay the same final price. Hence, the dominant strategy for bidders to reveal their true willingness to pay will result in fair market prices. Coupled with a pure on-chain design, the DutchX may function as a price oracle and is also usable for other smart contracts to convert tokens. Participants benefit from the redistribution of fees within the DutchX ecosystem as well.
@@ -567,7 +567,7 @@ export const AuctionMechanisms = ({ handleClick }: ContentPages) =>
     </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="how-dutchx-works">
       <h3>How a Dutch auction works</h3>
       <span>
       <p>While there are some variations to the mechanism, the main concept of a Dutch auction is that it starts with a high but falling price. The first person to make a bid will purchase the auctioned item for the current price at the bidding time.
@@ -576,7 +576,7 @@ export const AuctionMechanisms = ({ handleClick }: ContentPages) =>
     </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="what-is-batch-auction">
       <h3>What is a batch auction?</h3>
       <span>
       <p>Instead of trading continuously, the exchange collects the sell orders as batches until the auction starts, and clear them at the end of the auction all at once.<br/><br/>
@@ -586,7 +586,7 @@ export const AuctionMechanisms = ({ handleClick }: ContentPages) =>
     </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="dutchx-in-detail">
       <h3>The DutchX in detail</h3>
       <span>
       <p>The DutchX for a particular token-pairing (e.g. exchange Token A for Token B) changes between two states: (i) before the particular auction starts, and (ii) when an auction is running.
@@ -604,7 +604,7 @@ export const AuctionMechanisms = ({ handleClick }: ContentPages) =>
     </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="auction-over-time">
       <h3>What does each auction look like over time?</h3>
       <span>
       <p>Only one auction of the same pairing is run at the same time. Note that opposite auctions (i.e. opposite auction of Token A as sellToken and Token B as bidToken is Token B as sellToken and Token A as bidToken) run at the same time (they start simultaneously and finishing at their individual times).<br/><br/>
@@ -660,7 +660,7 @@ export const FAQ = ({ handleClick }: ContentPages) =>
         </p>
       </span>
     </section>
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="do-i-need-account">
       <h3>Do I need an account on the DutchX?</h3>
       <span>
         <p>
@@ -668,7 +668,7 @@ export const FAQ = ({ handleClick }: ContentPages) =>
         </p>
       </span>
     </section>
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="which-wallets-compatible">
       <h3>Which wallets are compatible with the DutchX?</h3>
       <span>
         <p>
@@ -676,25 +676,25 @@ export const FAQ = ({ handleClick }: ContentPages) =>
         </p>
       </span>
     </section>
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="how-to-link-wallet">
       <h3>How do I link my wallet to the DutchX?</h3>
       <span>
         <p>Your wallet is automatically linked to the DutchX. In case you are not logged into your wallet, you need to log in first.</p>
       </span>
     </section>
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="what-if-multiple-wallets">
       <h3>What if I have multiple wallets?</h3>
       <span>
         <p>It is recommended that you hold your relevant tokens, i.e. (1) those you want to participate with in the DutchX and (2) OWL in one wallet. (3) Additionally, it is recommended that you have your locked Magnolia stored in the same wallet: don’t spread your Magnolia over more wallet addresses as they are important for reducing your fees!</p>
       </span>
     </section>
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="which-wallet-is-linked">
       <h3>What if I have multiple wallets, which wallet is linked to the DutchX?</h3>
       <span>
         <p>It depends on which wallet connects to the browser first. If you want to participate with a different wallet, simply log out of the ones you do not want to participate with in the DutchX, and refresh your browser. Check out “Which wallets are compatible with the DutchX?”.</p>
       </span>
     </section>
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="need-to-know-about-wallet">
       <h3>What else do I need to know about my wallet?</h3>
       <span>
         <p>Very important—you need to have access to your private key! It's possible to send tokens to the DutchX from an address for which you do not have access to the private key. Please keep in mind that you can only claim tokens with the address you have sent tokens from!
@@ -702,19 +702,19 @@ export const FAQ = ({ handleClick }: ContentPages) =>
         </p>
       </span>
     </section>
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="why-not-all-tokens-in-wallet-shown">
       <h3>Why do I not see all tokens that I hold in my wallet on the DutchX header?</h3>
       <span>
         <p>The DutchX interface only displays those tokens that you can trade on this interface.</p>
       </span>
     </section>
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="why-0.0000-shown">
       <h3>Why do I see 0.0000 of a particular token in the header of the DutchX?</h3>
       <span>
         <p>The DutchX interface only display four decimals. In case you have an available balance which is less that 0.00009, the interface will only display '0.0000'.</p>
       </span>
     </section>
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="which-browsers-compatible">
       <h3>Which browsers are compatible with the DutchX?</h3>
       <span>
         <p>
@@ -722,63 +722,63 @@ export const FAQ = ({ handleClick }: ContentPages) =>
         </p>
       </span>
     </section>
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="is-it-safe-to-trade">
       <h3>Is it safe to trade in the DutchX?</h3>
       <span>
         <p>It is as safe as it gets! The DutchX is a non-custodial trading protocol. Your funds are only ever held in audited smart contracts. There still is a public bug bounty running and no bugs have been discovered. However, you need to make sure that you are the only one who has access to your private key! Still beware of phishing attacks.
         </p>
       </span>
     </section>
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="is-there-minimum-deposit">
       <h3>Is there a minimum deposit (order)?</h3>
       <span>
         <p>No, there is not.
         </p>
       </span>
     </section>
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="is-there-maximum-deposit">
       <h3>Is there a maximum deposit (order)?</h3>
       <span>
         <p>No, there is not.
         </p>
       </span>
     </section>
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="participate-in-more-acutions">
       <h3>Can I participate in more than one auction?</h3>
       <span>
         <p>Yes, definitely! You may participate in as many auctions as you would like. Note that for a specific token pair, there is only ever one auction running at a time. If you submit two separate orders for the same pair, and the auction had not started after your first order submission, your deposits will be placed into the same auction (and an accumulated amount will be displayed).
         </p>
       </span>
     </section>
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="participate-more-than-once">
       <h3>Can I participate more than once in the same auction?</h3>
       <span>
         <p>Yes, definitely! This will happen automatically if you submit two separate orders for the same pair, and the auction had not started after your first order. In this case, both your deposits will be placed into the same auction (and an accumulated amount will be displayed).
         </p>
       </span>
     </section>
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="why-no-mgn-generated">
       <h3>Why did my trade not generate Magnolia (MGN)?</h3>
       <span>
         <p>If your trade does not generate Magnolia, that is because one (or both) of the tokens part of the auction might not be whitelisted. Learn more on the topic in the section on <Link to={URLS.TOKENS + '#what-is-mgn'}>'Magnolia'</Link> and <Link to={URLS.TOKENS + '#what-are-whitelisted-tokens'}>'whitelisted tokens'</Link>.
         </p>
       </span>
     </section>
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="when-how-mgn-is-credited">
       <h3>When/how do I get Magnolia (MGN) credited?</h3>
       <span>
         <p>If your trade generated Magnolia, you are credited these automatically once you <Link to={URLS.HOW_IT_WORKS + '#how-do-i-claim-tokens'}>claim</Link> your new tokens (funds) from the auction. However, you will not see MGN as a balance in your wallet, as they are still locked. For your convenience, the amount of locked MGN is displayed in the header of the DutchX interface.
         </p>
       </span>
     </section>
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="why-no-mgn-balance-displayed">
       <h3>Why do I not see Magnolia (MGN) as a balance in my wallet?</h3>
       <span>
         <p>Magnolia are locked by default and can only then be used for fee reduction. Once you have claimed your new tokens, your MGN will be automatically credited to the wallet address used for the trade and are displayed in the header of the interface.
         </p>
       </span>
     </section>
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="why-no-mgn-in-header">
       <h3>Why can I not see my Magnolia (MGN) in the header?</h3>
       <span>
         <p>Make sure you are connected with the same wallet you participated with in the trade that generated those Magnolia (see section 'whitelisted tokens').
@@ -786,28 +786,28 @@ export const FAQ = ({ handleClick }: ContentPages) =>
         </p>
       </span>
     </section>
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="is-mgn-tradable">
       <h3>Is Magnolia (MGN) tradable?</h3>
       <span>
         <p>In theory, absolutely! MGN is an ERC20 token. However, please note that MGN are locked by default in order for you to make use of the fee reduction inherent to the DutchX. MGN are fungible and not personalized. At the moment, you won't be able to unlock your MGN on this interface. However, you will be in the next version of the DutchX.
         </p>
       </span>
     </section>
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="can-claim-deposits">
       <h3>Can I claim back my deposits (before or during an auction)?</h3>
       <span>
         <p>No, you cannot. Once you have placed your deposit into an auction, you will have to wait for the next auction to run and to close before you may claim the token you receive. In other words: after the final submission (“Order Confirmation” screen with your wallet provider), you cannot cancel your order and you cannot receive your deposit back.
         </p>
       </span>
     </section>
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="unhappy-with-amount-received">
       <h3>What do I do when I am not happy with the amount received?</h3>
       <span>
         <p>Unfortunately, there is nothing to do about it. You have received the fair market price at that time.
         </p>
       </span>
     </section>
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="how-to-claim-new-tokens">
       <h3>How can I claim my new tokens (funds)?
       </h3>
       <span>
@@ -815,7 +815,7 @@ export const FAQ = ({ handleClick }: ContentPages) =>
         </p>
       </span>
     </section>
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="notification-to-claim">
       <h3>Can I receive a notification indicating I can claim my new tokens (funds)?
       </h3>
       <span>
@@ -823,7 +823,7 @@ export const FAQ = ({ handleClick }: ContentPages) =>
         </p>
       </span>
     </section>
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="participate-with-fiat">
       <h3>Am I able to participate in the DutchX using fiat (e.g. USD, EUR)?
       </h3>
       <span>
@@ -831,7 +831,7 @@ export const FAQ = ({ handleClick }: ContentPages) =>
         </p>
       </span>
     </section>
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="what-is-weth">
       <h3>What is wrapped Ether (W-ETH) and why do I need it?
       </h3>
       <span>
@@ -842,7 +842,7 @@ export const FAQ = ({ handleClick }: ContentPages) =>
         </p>
       </span>
     </section>
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="trade-eth-and-weth">
       <h3>Can I trade both Ether and wrapped Ether?
       </h3>
       <span>
@@ -853,7 +853,7 @@ export const FAQ = ({ handleClick }: ContentPages) =>
         </p>
       </span>
     </section>
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="why-received-weth">
       <h3>I have received W-ETH instead of ETH, what happened?
       </h3>
       <span>
@@ -862,7 +862,7 @@ export const FAQ = ({ handleClick }: ContentPages) =>
         </p>
       </span>
     </section>
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="no-claimed-eth-in-wallet">
       <h3>I have claimed my ETH, but can't find them in my wallet—what happened?
       </h3>
       <span>
@@ -874,7 +874,7 @@ export const FAQ = ({ handleClick }: ContentPages) =>
       </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="approve-choices-meaning">
       <h3>What does “approve this trade only” and “approve also for future trades” mean?</h3>
       <span>
         <p>
@@ -889,7 +889,7 @@ export const FAQ = ({ handleClick }: ContentPages) =>
       </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="why-these-tokens-available">
       <h3>Why are exactly these tokens available on the interface?
       </h3>
       <span>
@@ -897,7 +897,7 @@ export const FAQ = ({ handleClick }: ContentPages) =>
       </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="requirements-to-add-token">
       <h3>What are the requirements for a token to be part of the curated list on the DutchX?
       </h3>
       <span>
@@ -905,7 +905,7 @@ export const FAQ = ({ handleClick }: ContentPages) =>
       </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="best-seller-strategy">
       <h3>What is my best strategy as a seller?
       </h3>
       <span>
@@ -913,15 +913,15 @@ export const FAQ = ({ handleClick }: ContentPages) =>
       </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="how-much-will-receive">
       <h3>I don’t know beforehand how much of a token I will receive —will I get the fair amount?</h3>
       <span>
-        <p>You do not know exactly how much of a token you will receive when you deposit your token— the interface will only show you an estimation based on the last auction outcome. Of course, prices may be volatile (up and down) and may change until your auction closes. However, at that point in time, it will be a fair price. To ensure that right incentives are set, we have implemented a few other safeguards beyond the mere auction design: 1) auctions only start once a threshold is reached to incentivize participation, 2) the market mechanisms applied have been explained to many market makers, 3) the tokens listed on this interface were curated based on minimal liquidity provision. This ensures that the seller always obtains at least a comparable market price as s/he would on a exchange (at auction closing time).
+        <p>You do not know exactly how much of a token you will receive when you deposit your token— the interface will only show you an estimation based on the last auction outcome. Of course, prices may be volatile (up and down) and may change until your auction closes. However, at that point in time, it will be a fair price. To ensure that right incentives are set, we have implemented a few other safeguards beyond the mere auction design: 1) auctions only start once a threshold is reached to incentivize participation, 2) the market mechanisms applied have been explained to many market makers, 3) the tokens listed on this interface were curated based on minimal liquidity provision. This ensures that the seller always obtains at least a comparable market price as s/he would on an exchange (at auction closing time).
         </p>
       </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="how-batch-auctions-are-applied">
       <h3>How does the DutchX apply batch auctions?</h3>
       <span>
         <p>Instead of trading continuously, the DutchX collects the sell orders as batches until the auction starts, and clears them at the end of the auction all at once.
@@ -931,14 +931,14 @@ export const FAQ = ({ handleClick }: ContentPages) =>
       </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="which-data-is-collected">
       <h3>Which data do you collect?</h3>
       <span>
         <p>Whenever you take part in a trade on the DutchX, transactions are stored on immutable public blockchains. For more information, please refer to the <a href="../docs/DutchX_Rinkeby_PrivacyPolicy.pdf" target="_blank">Privacy Policy</a> in the footer.</p>
       </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="price-fairness">
       <h3>How can I be sure that the price I receive is fair?</h3>
       <span>
         <p>The DutchX mechanism is as fair as it gets! However, it reflects the current market price. Of course, the mechanism only works if there is a critical mass participating. This is why an automated trading service will guarantee that the price does not drop significantly below the market price of other trading platforms.
@@ -947,49 +947,49 @@ export const FAQ = ({ handleClick }: ContentPages) =>
       </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="how-is-liquidoty-provided">
       <h3>How is liquidity provided?</h3>
       <span>
         <p>To ensure that a critical trading mass is reached and markets work well, there will be an automated trading service at the beginning, ensuring that the market price does not drop significantly below the market price of other trading platforms. Where markets develop sufficient liquidity, the automated trading service is expected to cease.</p>
       </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="how-high-are-gas-costs">
       <h3>How high will my gas costs be?</h3>
       <span>
         <p>For every transaction to the blockchain, you will incur gast costs. As an example: In order to trade a token (depositing and claiming back) it will be a total of about 175k gas. The total cost depends on the gas price you set. At 10Gwei (and an assumed ETH-USD rate of 400), this would equal 0.70 USD.</p>
       </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="what-is-preselected-gas-price">
       <h3>What is the preselected gas price?</h3>
       <span>
         <p>The interface does not override your wallet provider’s suggestion for a gas price. It will be using the default rate of your wallet provider. You may change it directly on your wallet provider's interface.</p>
       </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="which-gas-price-to-set">
       <h3>Which gas price should I set?</h3>
       <span>
         <p>For transactions that are not time critical (and for which you do not mind waiting), you can set the gas price low to save gas costs.</p>
       </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="high-gas-price-advantage">
       <h3>Do I have an advantage with a higher gas price?</h3>
       <span>
         <p>No, not really—the mechanism of the DutchX is to batch orders and execute them at the same clearing price. What could happen with a lower gas price is that your order then gets submitted to the subsequent auction—but the logic here is the same! Hence, the only consequence would be that claiming your new tokens will get delayed. Also note that the processing of transactions takes time, hence you might need to wait longer until your order has gone through.</p>
       </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="transaction-problems">
       <h3>Something has gone wrong with my transaction, what happened?</h3>
       <span>
         <p>If a transaction fails, usually your wallet provider will tell you what happened. These errors will relate to the nature of the blockchain. Possible explanations include (but are not limited to): (1) you did not have sufficient ETH to pay for your gas costs, or (2) the gas price you had set was too low and thus the transaction was not mined. However, rest assured that you will not incur a loss of funds if a transaction hasn't gone through.</p>
       </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="what-price-feed-is-used">
       <h3>What price feed is the DutchX using?</h3>
       <span>
         <p>
@@ -998,21 +998,21 @@ export const FAQ = ({ handleClick }: ContentPages) =>
       </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="why-price-feed-is-needed">
       <h3>What does the DutchX need the ETH/USD price feed for?</h3>
       <span>
         <p>The ETH/USD price feed is needed for three calculations: 1) the initialisation (first listing) of a token, 2) the start of an auction, and 3) the calculation of <Link to={URLS.FEES + '#fees'}>fees</Link> in USD or OWL.</p>
       </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="can-i-use-dutchx-code">
       <h3>Can I copy, alter, and use the code of the DutchX?</h3>
       <span>
         <p>You may do everything that is allowed based on the licenses attached to the code. This is not to be considered legal advice and no further information can be given.</p>
       </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="how-to-participate-as-buyer">
       <h3>How do I participate as a buyer?</h3>
       <span>
         <p>Unfortunately, there is currently no interface to participate in the bidding as development work was focused on providing this interface for you. If there is the demand for it, a bidder interface will be created in the future.
@@ -1021,7 +1021,7 @@ export const FAQ = ({ handleClick }: ContentPages) =>
       </span>
     </section>
 
-    <section className="drawer" onClick={handleClick}>
+    <section className="drawer" onClick={handleClick} id="what-happens-in-case-of-downtime">
       <h3>What happens in case of downtime?</h3>
       <span>
         <p>Unfortunately, there is no guarantee of keeping this interface available to you at all times. If the interface is down for maintenance, it will be communicated early on.In case the site is down due to unforeseen reasons, this will be communicated via the DutchX Twitter account (@DutchX_).

--- a/src/components/ContentPage/index.tsx
+++ b/src/components/ContentPage/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { URLS } from 'globals'
+import { Link } from 'react-router-dom'
 
 import 'assets/pdf/DutchX_Rinkeby_PrivacyPolicy.pdf'
 
@@ -8,7 +9,7 @@ interface ContentPages {
   handleSectionMove: (id: string, url?: string) => void;
 }
 
-export const HowItWorks = ({ handleClick, handleSectionMove }: ContentPages) => (
+export const HowItWorks = ({ handleClick }: ContentPages) => (
   <article>
     <h1>How the DutchX works</h1>
 
@@ -88,7 +89,7 @@ export const HowItWorks = ({ handleClick, handleSectionMove }: ContentPages) => 
           <br/>
           <br/>
           The second option is via the specific URL for the auction pair (auction overview page). You will automatically access the URL at the end of the order process. From there, you may claim the new token particular to that specific auction (you will only need to sign one transaction with your wallet provider).
-          Note that you have to be connected to the same wallet that you used to participate in the auction in order to claim your new tokens! Please also check out the <span className="sectionLink" onClick={() => handleSectionMove('step-by-step-claiming')}>step-by-step guide</span> about claiming tokens.
+          Note that you have to be connected to the same wallet that you used to participate in the auction in order to claim your new tokens! Please also check out the <Link to="#step-by-step-claiming">step-by-step guide</Link> about claiming tokens.
         </p>
       </span>
     </section>
@@ -125,7 +126,7 @@ export const HowItWorks = ({ handleClick, handleSectionMove }: ContentPages) => 
         <p>You only need three things:</p>
         <ol>
           <li>A compatible (and connected) wallet. Currently only <a href={URLS.METAMASK} target="_blank">MetaMask</a> is supported.</li>
-          <li>An <span className="sectionLink" onClick={() => handleSectionMove('what-is-erc20', URLS.FAQ)}>ERC20</span> token or ETH. To see a list of tokens that you can currently trade on this interface, click on the <i>deposit</i> or <i>receive</i> token. </li>
+          <li>An <Link to={URLS.FAQ + '#what-is-erc20'}>ERC20</Link> token or ETH. To see a list of tokens that you can currently trade on this interface, click on the <i>deposit</i> or <i>receive</i> token. </li>
           <li>ETH in your wallet to pay for transactions fees (both to submit a deposit (=order) and to claim your new tokens).</li>
         </ol>
         <p>No other tokens are needed!</p>
@@ -148,7 +149,7 @@ export const HowItWorks = ({ handleClick, handleSectionMove }: ContentPages) => 
                 Wrapping ETH will be the first confirmation which you will see, but only if you need to wrap ETH (i.e. to make it ERC20 compatible). Please always confirm with your wallet provider.
               </li>
               <li>
-                Paying for fees in OWL: If you have <span className="sectionLink" onClick={() => handleSectionMove('what-are-owl', URLS.FEES)}>OWL</span> in your linked wallet, you will be asked whether you would like to pay for half of your <span className="sectionLink" onClick={() => handleSectionMove('fees', URLS.FEES)}>fees</span> in OWL (as long as you have a positive OWL balance).
+                Paying for fees in OWL: If you have <Link to={URLS.FEES + '#what-are-owl'}>OWL</Link> in your linked wallet, you will be asked whether you would like to pay for half of your <Link to={URLS.FEES + '#fees'}>fees</Link> in OWL (as long as you have a positive OWL balance).
               </li>
               <li>
                 Confirming the token transfer on the screen (either for this trade only or for future transaction with the same tokens).
@@ -193,7 +194,7 @@ export const HowItWorks = ({ handleClick, handleSectionMove }: ContentPages) => 
           <li>The second option is via the specific URL for the auction pair. You will automatically access the URL at the end of the deposit process. From there, you may claim the token particularly to that specific auction. You will only need to sign once.</li>
         </ul>
 
-        <p><strong>Important: If your trade generated <span className="sectionLink" onClick={() => handleSectionMove('what-is-mgn', URLS.TOKENS)}>Magnolia (MGN)</span>, you will be credited those automatically upon claiming your new tokens. MGN are locked by default and are visible to you in the header bar of the interface.</strong></p>
+        <p><strong>Important: If your trade generated <Link to={URLS.TOKENS + '#what-is-mgn'}>Magnolia (MGN)</Link>, you will be credited those automatically upon claiming your new tokens. MGN are locked by default and are visible to you in the header bar of the interface.</strong></p>
         <br/>
         <p><strong>Note that you have to be connected to the same wallet that you participated with in order to claim!</strong></p>
       </span>
@@ -221,7 +222,7 @@ export const HowItWorks = ({ handleClick, handleSectionMove }: ContentPages) => 
       <span>
         <p>
           MGN is the abbreviation for the Magnolia token. Locked MGN reduce your fee level. One MGN is automatically created for every ETH-worth of whitelisted token trades you make. You will receive them automatically upon claiming your new tokens. The more you trade, the more MGN you will receive, the lower your fee.
-          For more info, check out the section on <span className="sectionLink" onClick={() => handleSectionMove('what-is-mgn', URLS.TOKENS)}>Magnolia</span>.
+          For more info, check out the section on <Link to={URLS.TOKENS + '#what-is-mgn'}>Magnolia</Link>.
           In the header bar of the interface, the amount of locked MGN associated with your linked wallet is displayed. However, you will not see this amount in your wallet.
           Of course, you do not need to hold any MGN to participate in the DutchX!
         </p>
@@ -231,21 +232,21 @@ export const HowItWorks = ({ handleClick, handleSectionMove }: ContentPages) => 
     <section className="drawer" onClick={handleClick}>
       <h3>What is my fee level?</h3>
       <span>
-        <p>By default, your fee level is 0.5% of your trading volume. It taken from the deposited amount. You may lower your fees by trading frequently or holding MGN. For more info, check out the <span className="sectionLink" onClick={() => handleSectionMove('fees', URLS.FEES)}>Fee</span> section.</p>
+        <p>By default, your fee level is 0.5% of your trading volume. It taken from the deposited amount. You may lower your fees by trading frequently or holding MGN. For more info, check out the <Link to={URLS.FEES + '#fees'}>Fee</Link> section.</p>
       </span>
     </section>
 
     <section className="drawer" onClick={handleClick}>
       <h3>What does “Any auction with [Token] won’t generate MGN” mean?</h3>
       <span>
-        <p>This message is to inform you about whether the token you are looking to trade generates Magnolia (which is used for fee-reduction) when you trade it. Find more information on this process <span className="sectionLink" onClick={() => handleSectionMove('what-is-mgn', URLS.TOKENS)}>here</span>. You can still use the trading interface in the same manner for tokens that do and do not generate Magnolia.</p>
+        <p>This message is to inform you about whether the token you are looking to trade generates Magnolia (which is used for fee-reduction) when you trade it. Find more information on this process <Link to={URLS.TOKENS + '#what-is-mgn'}>here</Link>. You can still use the trading interface in the same manner for tokens that do and do not generate Magnolia.</p>
       </span>
     </section>
 
     <section className="drawer" id="claiming" onClick={handleClick}>
       <h3>What does “Note: this token pair won’t generate MGN tokens” mean?</h3>
       <span>
-        <p>This message is to inform you about whether the token pair generates Magnolia (which is used for fee-reduction) when you trade it. If one token out of the pair does not generate Magnolia, the entire token pair will not generate Magnolia. You can use the trading interface in the same manner for tokens that do and do not generate Magnolia. Find more information on this <span className="sectionLink" onClick={() => handleSectionMove('what-is-mgn', URLS.TOKENS)}>here</span>.
+        <p>This message is to inform you about whether the token pair generates Magnolia (which is used for fee-reduction) when you trade it. If one token out of the pair does not generate Magnolia, the entire token pair will not generate Magnolia. You can use the trading interface in the same manner for tokens that do and do not generate Magnolia. Find more information on this <Link to={URLS.TOKENS + '#what-is-mgn'}>here</Link>.
           <br />
           <br />
           Want to bid in an auction? This is currently only possible for technical participants: read <a href={URLS.DUTCHX_DEVS_AND_API} target="_blank">DutchX for Devs & API</a>.
@@ -266,7 +267,7 @@ export const Screencast = () =>
   </article>
 
 {/* TOKENS - page */}
-export const Tokens = ({ handleClick, handleSectionMove }: ContentPages) =>
+export const Tokens = ({ handleClick }: ContentPages) =>
   <article>
     <h1>Tokens</h1>
 
@@ -294,7 +295,7 @@ export const Tokens = ({ handleClick, handleSectionMove }: ContentPages) =>
       <h3>What token do I need to be active on the DutchX?</h3>
       <span>
       <p>
-        You do not need to own any particular token to trade on the DutchX! However, keep in mind that you need ETH to pay for gas costs. Check out "<span className="sectionLink" onClick={() => handleSectionMove('what-do-i-need-to-trade-on-dx', URLS.HOW_IT_WORKS)}>What do I need to trade a token on the DutchX</span>"?
+        You do not need to own any particular token to trade on the DutchX! However, keep in mind that you need ETH to pay for gas costs. Check out "<Link to={URLS.HOW_IT_WORKS + '#what-do-i-need-to-trade-on-dx'}>What do I need to trade a token on the DutchX</Link>"?
       </p>
     </span>
     </section>
@@ -347,7 +348,7 @@ export const Tokens = ({ handleClick, handleSectionMove }: ContentPages) =>
 
   </article>
 
-export const Fees = ({ handleClick, handleSectionMove }: ContentPages) =>
+export const Fees = ({ handleClick }: ContentPages) =>
   <article id="fees">
     <h1>Fees</h1>
     <section className="drawer" onClick={handleClick}>
@@ -361,7 +362,7 @@ export const Fees = ({ handleClick, handleSectionMove }: ContentPages) =>
       <h3>How can I lower my fees?</h3>
       <span>
         <p>
-          Your fees will be lowered automatically for you if you hold <span className="sectionLink" onClick={() => handleSectionMove('what-is-mgn', URLS.TOKENS)}>Magnolia</span> tokens. The amount by which the fees are lowered depends on how much Magnolia you hold in relation to the entire Magnolia market volume. It is based on this neat step function:
+          Your fees will be lowered automatically for you if you hold <Link to={URLS.TOKENS + '#what-is-mgn'}>Magnolia</Link> tokens. The amount by which the fees are lowered depends on how much Magnolia you hold in relation to the entire Magnolia market volume. It is based on this neat step function:
         </p>
         {/*TODO: add <img id='fee-reduction-image'> */}
         <table>
@@ -411,8 +412,8 @@ export const Fees = ({ handleClick, handleSectionMove }: ContentPages) =>
       <h3>How do I obtain Magnolia (MGN)?</h3>
       <span>
       <p>
-        You may either generate Magnolia by trading on the DutchX (with a whitelisted trading pair). For more info, see the section on <span className="sectionLink" onClick={() => handleSectionMove('what-is-mgn', URLS.TOKENS)}>Magnolia</span>.
-        Alternatively, you could also purchase MGN since they are freely tradable. This may be particularly beneficial if you are close to the <span className="sectionLink" onClick={() => handleSectionMove('fee-reduction-image')}>next fee reduction level</span>.
+        You may either generate Magnolia by trading on the DutchX (with a whitelisted trading pair). For more info, see the section on <Link to={URLS.TOKENS + '#what-is-mgn'}>Magnolia</Link>.
+        Alternatively, you could also purchase MGN since they are freely tradable. This may be particularly beneficial if you are close to the <Link to="#fee-reduction-image">next fee reduction level</Link>.
       </p>
     </span>
     </section>
@@ -646,7 +647,7 @@ export const OpenPlatform = () =>
 {/* END DutchX as an Open Platform - page */}
 
 {/* FAQ - page */}
-export const FAQ = ({ handleClick, handleSectionMove }: ContentPages) =>
+export const FAQ = ({ handleClick }: ContentPages) =>
   <article id="FAQ">
     <h1>FAQ</h1>
     <section className="content">
@@ -760,14 +761,14 @@ export const FAQ = ({ handleClick, handleSectionMove }: ContentPages) =>
     <section className="drawer" onClick={handleClick}>
       <h3>Why did my trade not generate Magnolia (MGN)?</h3>
       <span>
-        <p>If your trade does not generate Magnolia, that is because one (or both) of the tokens part of the auction might not be whitelisted. Learn more on the topic in the section on <span className="sectionLink" onClick={() => handleSectionMove('what-is-mgn', URLS.TOKENS)}>'Magnolia'</span> and <span className="sectionLink" onClick={() => handleSectionMove('what-are-whitelisted-tokens', URLS.TOKENS)}>'whitelisted tokens'</span>.
+        <p>If your trade does not generate Magnolia, that is because one (or both) of the tokens part of the auction might not be whitelisted. Learn more on the topic in the section on <Link to={URLS.TOKENS + '#what-is-mgn'}>'Magnolia'</Link> and <Link to={URLS.TOKENS + '#what-are-whitelisted-tokens'}>'whitelisted tokens'</Link>.
         </p>
       </span>
     </section>
     <section className="drawer" onClick={handleClick}>
       <h3>When/how do I get Magnolia (MGN) credited?</h3>
       <span>
-        <p>If your trade generated Magnolia, you are credited these automatically once you <span className="sectionLink" onClick={() => handleSectionMove('how-do-i-claim-tokens', URLS.HOW_IT_WORKS)}>claim</span> your new tokens (funds) from the auction. However, you will not see MGN as a balance in your wallet, as they are still locked. For your convenience, the amount of locked MGN is displayed in the header of the DutchX interface.
+        <p>If your trade generated Magnolia, you are credited these automatically once you <Link to={URLS.HOW_IT_WORKS + '#how-do-i-claim-tokens'}>claim</Link> your new tokens (funds) from the auction. However, you will not see MGN as a balance in your wallet, as they are still locked. For your convenience, the amount of locked MGN is displayed in the header of the DutchX interface.
         </p>
       </span>
     </section>
@@ -827,7 +828,7 @@ export const FAQ = ({ handleClick, handleSectionMove }: ContentPages) =>
       <h3>Am I able to participate in the DutchX using fiat (e.g. USD, EUR)?
       </h3>
       <span>
-        <p>Unfortunately, you cannot trade anything but <span className="sectionLink" onClick={() => handleSectionMove('what-is-erc20', URLS.FAQ)}>ERC20 tokens</span> and ETH on this interface.
+        <p>Unfortunately, you cannot trade anything but <Link to={URLS.FAQ + '#what-is-erc20'}>ERC20 tokens</Link> and ETH on this interface.
         </p>
       </span>
     </section>
@@ -901,7 +902,7 @@ export const FAQ = ({ handleClick, handleSectionMove }: ContentPages) =>
       <h3>What are the requirements for a token to be part of the curated list on the DutchX?
       </h3>
       <span>
-        <p>It is expected that a minimal liquidity provision is guaranteed. Apart from that, the token must not be considered a security by any authority, law firm or any decentral or central exchange. A certain market cap should also weigh in for sufficient liquidity. For more information, please <span className="sectionLink" onClick={() => handleSectionMove(undefined, URLS.HELP)}>reach out</span>.</p>
+        <p>It is expected that a minimal liquidity provision is guaranteed. Apart from that, the token must not be considered a security by any authority, law firm or any decentral or central exchange. A certain market cap should also weigh in for sufficient liquidity. For more information, please <Link to={URLS.HELP}>reach out</Link>.</p>
       </span>
     </section>
 
@@ -1001,7 +1002,7 @@ export const FAQ = ({ handleClick, handleSectionMove }: ContentPages) =>
     <section className="drawer" onClick={handleClick}>
       <h3>What does the DutchX need the ETH/USD price feed for?</h3>
       <span>
-        <p>The ETH/USD price feed is needed for three calculations: 1) the initialisation (first listing) of a token, 2) the start of an auction, and 3) the calculation of <span className="sectionLink" onClick={() => handleSectionMove('fees', URLS.FEES)}>fees</span> in USD or OWL.</p>
+        <p>The ETH/USD price feed is needed for three calculations: 1) the initialisation (first listing) of a token, 2) the start of an auction, and 3) the calculation of <Link to={URLS.FEES + '#fees'}>fees</Link> in USD or OWL.</p>
       </span>
     </section>
 
@@ -1060,11 +1061,11 @@ export const Downtime = () =>
   </article>
 
 {/* Help - page */}
-export const Help = ({ handleSectionMove }: ContentPages) =>
+export const Help = () =>
   <article>
     <h1>Help</h1>
     <section className="content">
-      <p>Haven’t found the answer to your question in the <span className="sectionLink" onClick={() => handleSectionMove('faqs', URLS.FAQ)}>FAQ</span>?
+      <p>Haven’t found the answer to your question in the <Link to={URLS.FAQ + '#faqs'}>FAQ</Link>?
       <br/>
       For all questions from and for developers, get in touch on the <a href={URLS.GITTER_URL} target="_blank">Gitter channel</a>.
       <br/>

--- a/src/components/Modals/index.tsx
+++ b/src/components/Modals/index.tsx
@@ -123,8 +123,7 @@ export const ApprovalModal: React.SFC<ApprovalModalProps> = ({
           {footer.msg || null}
           <br/>
           <br/>
-          {/* why not use Link here? */}
-          For more information, read the <a href={footer.url || './content/FAQ/#approval'} target="_blank">{footer.urlMsg || ' linked'}</a> page.
+          For more information, read the <a href={footer.url || '#/content/FAQ/#approval'} target="_blank">{footer.urlMsg || ' linked'}</a> page.
         </i>
       </p>}
   </div>

--- a/src/components/Modals/index.tsx
+++ b/src/components/Modals/index.tsx
@@ -69,7 +69,7 @@ export const TransactionModal: React.SFC<TransactionModalProps> = ({
     {button &&
     <button
       className="modalButton"
-      onClick={() => closeModal()}
+      onClick={closeModal}
     >
       CLOSE
     </button>
@@ -123,6 +123,7 @@ export const ApprovalModal: React.SFC<ApprovalModalProps> = ({
           {footer.msg || null}
           <br/>
           <br/>
+          {/* why not use Link here? */}
           For more information, read the <a href={footer.url || './content/FAQ/#approval'} target="_blank">{footer.urlMsg || ' linked'}</a> page.
         </i>
       </p>}

--- a/src/components/OrderPanel/index.tsx
+++ b/src/components/OrderPanel/index.tsx
@@ -16,8 +16,6 @@ interface OrderPanelProps {
   validSellAmount: boolean,
   generatesMGN: boolean,
   overlayOpen: boolean,
-
-  pushAndMoveToElement: (id: string, url?: string) => void
 }
 
 const OrderPanel: React.SFC<OrderPanelProps> = ({ sellTokenSymbol, buyTokenSymbol, validSellAmount, generatesMGN, overlayOpen }) => (

--- a/src/components/OrderPanel/index.tsx
+++ b/src/components/OrderPanel/index.tsx
@@ -8,6 +8,7 @@ import ButtonCTA from 'components/ButtonCTA'
 import TokenPair from 'containers/TokenPair'
 import TokenOverlay from 'containers/TokenOverlay'
 import { URLS } from 'globals'
+import { Link } from 'react-router-dom'
 
 interface OrderPanelProps {
   sellTokenSymbol: string,
@@ -19,7 +20,7 @@ interface OrderPanelProps {
   pushAndMoveToElement: (id: string, url?: string) => void
 }
 
-const OrderPanel: React.SFC<OrderPanelProps> = ({ sellTokenSymbol, buyTokenSymbol, validSellAmount, generatesMGN, overlayOpen, pushAndMoveToElement }) => (
+const OrderPanel: React.SFC<OrderPanelProps> = ({ sellTokenSymbol, buyTokenSymbol, validSellAmount, generatesMGN, overlayOpen }) => (
   <AuctionContainer auctionDataScreen="amount">
     {overlayOpen && <TokenOverlay />}
     <AuctionHeader backTo="/">
@@ -27,7 +28,7 @@ const OrderPanel: React.SFC<OrderPanelProps> = ({ sellTokenSymbol, buyTokenSymbo
     </AuctionHeader>
 
     {/* Display 'pair-noMGN' when this pair won't generate MGN tokens (any of the picked token causing this) */}
-    {sellTokenSymbol && buyTokenSymbol && !generatesMGN && <div className="pair-noMGN">Note: this token pair <span className="sectionLink" onClick={() => pushAndMoveToElement('what-is-mgn', URLS.TOKENS)}>won't generate MGN tokens</span></div>}
+    {sellTokenSymbol && buyTokenSymbol && !generatesMGN && <div className="pair-noMGN">Note: this token pair <Link to={URLS.TOKENS + '#what-is-mgn'}>won't generate MGN tokens</Link></div>}
     {/* END */}
 
     <TokenPair />

--- a/src/containers/ContentPages/index.tsx
+++ b/src/containers/ContentPages/index.tsx
@@ -27,7 +27,7 @@ interface EventTarget {
 
 export const grabElementID = (id: string) => document.getElementById(id)
 
-class ContentPageContainer extends React.Component<ContentPageContainerProps & any> {
+class ContentPageContainer extends React.Component<ContentPageContainerProps> {
   outerDiv: HTMLElement
 
   /* componentDidMount() {
@@ -63,6 +63,7 @@ class ContentPageContainer extends React.Component<ContentPageContainerProps & a
 }
 
 const mapDispatch = (dispatch: Dispatch<any>) => ({
+  // why use bindActionCreators?
   pushAndMoveToElement: bindActionCreators(pushAndMoveToElement, dispatch),
 })
 

--- a/src/containers/ContentPages/index.tsx
+++ b/src/containers/ContentPages/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { connect, Dispatch } from 'react-redux'
-import { Redirect } from 'react-router-dom'
+import { Redirect, RouteProps } from 'react-router-dom'
 
 import * as ContentPages from 'components/ContentPage'
 
@@ -8,7 +8,7 @@ import { bindActionCreators } from 'redux'
 
 import { pushAndMoveToElement } from 'actions'
 
-export interface ContentPageContainerProps {
+export interface ContentPageContainerProps extends RouteProps {
   match: {
     params: {
       contentPage: string,
@@ -30,9 +30,31 @@ export const grabElementID = (id: string) => document.getElementById(id)
 class ContentPageContainer extends React.Component<ContentPageContainerProps> {
   outerDiv: HTMLElement
 
-  /* componentDidMount() {
-    this.outerDiv && this.outerDiv.focus()
-  } */
+  componentDidMount() {
+    // scroll to element if needed on initial visit
+    this.scrollToHash()
+  }
+
+  componentDidUpdate(prevProps: ContentPageContainerProps) {
+    const { hash, pathname } = this.props.location
+    const { hash: prevHash, pathname: prevPathname } = prevProps.location
+
+    if (hash === prevHash && pathname === prevPathname) return
+    // on path change, check if need to scroll to an element
+    this.scrollToHash()
+  }
+
+  scrollToHash(hash = this.props.location.hash) {
+    if (hash) {
+      const elem = document.querySelector(hash)
+      if (elem) {
+        const { classList } = elem
+        // only apply .active to .drawer
+        if (classList.contains('drawer')) classList.add('active')
+        elem.scrollIntoView()
+      }
+    }
+  }
 
   renderContentPage = (name: string, props?: any) => {
     const Component = ContentPages[name]

--- a/src/containers/ContentPages/index.tsx
+++ b/src/containers/ContentPages/index.tsx
@@ -1,12 +1,7 @@
 import React from 'react'
-import { connect, Dispatch } from 'react-redux'
 import { Redirect, RouteProps } from 'react-router-dom'
 
 import * as ContentPages from 'components/ContentPage'
-
-import { bindActionCreators } from 'redux'
-
-import { pushAndMoveToElement } from 'actions'
 
 export interface ContentPageContainerProps extends RouteProps {
   match: {
@@ -14,8 +9,6 @@ export interface ContentPageContainerProps extends RouteProps {
       contentPage: string,
     },
   };
-  children?: JSX.Element;
-  pushAndMoveToElement(id: string, url?: string): () => any;
 }
 
 interface EventTarget {
@@ -67,7 +60,7 @@ class ContentPageContainer extends React.Component<ContentPageContainerProps> {
   }
 
   render() {
-    const { match: { params: { contentPage } }, pushAndMoveToElement } = this.props
+    const { match: { params: { contentPage } } } = this.props
     return (
       ContentPages[contentPage]
       ?
@@ -76,7 +69,7 @@ class ContentPageContainer extends React.Component<ContentPageContainerProps> {
           /* ref={c => this.outerDiv = c} */
           tabIndex={1}
         >
-          {this.renderContentPage(contentPage, { handleClick: this.handleClick, handleSectionMove: pushAndMoveToElement })}
+          {this.renderContentPage(contentPage, { handleClick: this.handleClick })}
         </div>
       :
         <Redirect to="/404" />
@@ -84,9 +77,4 @@ class ContentPageContainer extends React.Component<ContentPageContainerProps> {
   }
 }
 
-const mapDispatch = (dispatch: Dispatch<any>) => ({
-  // why use bindActionCreators?
-  pushAndMoveToElement: bindActionCreators(pushAndMoveToElement, dispatch),
-})
-
-export default connect(undefined, mapDispatch)(ContentPageContainer)
+export default ContentPageContainer

--- a/src/containers/OrderPanel/index.ts
+++ b/src/containers/OrderPanel/index.ts
@@ -3,7 +3,6 @@ import { connect } from 'react-redux'
 import OrderPanel from 'components/OrderPanel'
 import { RedirectHomeIfNoAccountHOC } from 'components/RedirectIf'
 
-import { pushAndMoveToElement } from 'actions'
 import { getSellTokenBalance } from 'selectors'
 
 import { State, BigNumber } from 'types'
@@ -30,4 +29,4 @@ const mapStateToProps = (state: State) => {
   }
 }
 
-export default connect(mapStateToProps, { pushAndMoveToElement })(RedirectHomeIfNoAccountHOC(OrderPanel))
+export default connect(mapStateToProps, null)(RedirectHomeIfNoAccountHOC(OrderPanel))

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -3,7 +3,6 @@
   <head>
       <meta charset="utf-8">
       <meta name="viewport" content="width=device-width, initial-scale=1">
-      <link rel="icon" href="/img/dutchx.png">
       <title>DutchX</title>
   </head>
   <body>


### PR DESCRIPTION
Switch to use react-router's `Link` instead of `pushAndMoveToElement`

Now possible to open page to `/#/content/FAQ#what-is-erc20` and the section will be unfolded already.

+ other small changes