### PR TITLE
Fix NO AUCTIONS alignment

### DIFF
--- a/src/styles/components/navbar/_navbar.scss
+++ b/src/styles/components/navbar/_navbar.scss
@@ -685,7 +685,8 @@ header {
     margin: 0;
     z-index: 99;
     cursor: default;
-    left: -71%;
+    left: -50%;
+    transform: translateX(-50%);
     box-shadow: 0 15px 35px rgba(50,50,93,.1), 0 5px 15px rgba(0,0,0,.07);
     border: 2px solid transparent;
     max-height: 660px;


### PR DESCRIPTION
`.menuAuctions > div` has a lot of fixed sizes, which moves the whole hover off center when its children don't take much space:
![dx staging gnosisdev com_ 4](https://user-images.githubusercontent.com/5121491/45539175-9fd08d80-b811-11e8-9da5-7820e2840e03.png)

This makes it better:
![dx staging gnosisdev com_ 5](https://user-images.githubusercontent.com/5121491/45539195-ac54e600-b811-11e8-9ac2-53cd10881943.png)

