### PR TITLE
add ID check param to web3Network check to fix block

### DIFF
--- a/src/block.ts
+++ b/src/block.ts
@@ -26,8 +26,8 @@ export const isNetBlocked = async (idsToAllow: (string | number)[]) => {
   if (typeof window === 'undefined' || !window.web3) return false
 
   try {
-    const id = await web3CompatibleNetwork()
-
+    // grab net ID, not string name - [true = IDs e.g 4] WHILE [blank or FALSE = NetworkName e.g 'Rinkeby']
+    const id = await web3CompatibleNetwork(true)
     // allow network ID matching at least 1 passed in from idsToAllow
     // and local testrpc (id = Date.now()) >> Apr 29 2018
     if (idsToAllow.includes(id as string) || +id > 1525000000000) return false

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -203,7 +203,7 @@ export const provider2SVG = (providerName: ProviderName | ProviderType) => {
   }
 }
 
-export const web3CompatibleNetwork = async () => {
+export const web3CompatibleNetwork = async (id?: boolean) => {
   await windowLoaded
   if (typeof window === 'undefined' || !window.web3 || !window.web3.version) return (console.debug('no window or window.web3 or window.web3.version'), 'UNKNOWN')
 
@@ -223,7 +223,7 @@ export const web3CompatibleNetwork = async () => {
   } else {
     // 0.XX.xx API
     // without windowLoaded web3 can be injected but network id not yet set
-    netID = await getNetwork(window as any).catch((err: Error) => (console.error(err), 'UNKNOWN'))
+    netID = await getNetwork(window as any, id).catch((err: Error) => (console.error(err), 'UNKNOWN'))
   }
 
   return netID


### PR DESCRIPTION
HOTFIX

1. add ID check param to web3Network check to fix block
  a. due to a change in params in web3CompatibleNetwork fn, block function was checking against network STRING NAME e.g Rinkeby or Main instead of it's ID e.g 1 || 4 || 42 etc
