### PR TITLE
DX-Contract DutchX 1.0.8 >> 1.0.9 w/Pinned Utils && GNO Contract versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1136,46 +1136,51 @@
       }
     },
     "@gnosis.pm/dx-contracts": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@gnosis.pm/dx-contracts/-/dx-contracts-1.0.8.tgz",
-      "integrity": "sha512-aRSGnPCMOpEXBWOfVEC3A7Xoh0LSwQCfw8ipsP1BQqaKtCq3HlEO4hmJZ2DafBHptVleHVZ6if/h0ZVovkqsyA==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@gnosis.pm/dx-contracts/-/dx-contracts-1.0.9.tgz",
+      "integrity": "sha512-pQ8T/dLHVy30hl764IkAalM7ZdiuJuNhrIh7mNYoo73RnJOOZxZP2ist9kunXVcJYWaDawJ3qx+Y0n4mKx+cQQ==",
       "requires": {
-        "@gnosis.pm/gno-token": "^1.0.1",
-        "@gnosis.pm/owl-token": "^1.1.2",
-        "@gnosis.pm/util-contracts": "^1.0.2"
-      }
-    },
-    "@gnosis.pm/gno-token": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@gnosis.pm/gno-token/-/gno-token-1.1.2.tgz",
-      "integrity": "sha512-Q7OBervGf5jL/SRcYSwbkySoY37De+S6WHzT2isLPSXTdneLFUofvFgwzWypYI1U5WeFZozXBsrfIxyi+tbppw==",
-      "requires": {
-        "@gnosis.pm/util-contracts": "1.1.1"
-      }
-    },
-    "@gnosis.pm/owl-token": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@gnosis.pm/owl-token/-/owl-token-1.2.3.tgz",
-      "integrity": "sha512-OIEBZLhh6pZZgkABIk5bSQzWgvCfvgF+rz3/reN/YoShA+A10Z2WvixTrSEiWBZHTYm3EgP3UCLnmxN5gWupHA==",
-      "requires": {
-        "@gnosis.pm/gno-token": "1.1.2",
-        "@gnosis.pm/util-contracts": "1.1.1"
+        "@gnosis.pm/gno-token": "1.0.1",
+        "@gnosis.pm/owl-token": "1.1.2",
+        "@gnosis.pm/util-contracts": "1.0.2"
       },
       "dependencies": {
         "@gnosis.pm/gno-token": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/@gnosis.pm/gno-token/-/gno-token-1.1.2.tgz",
-          "integrity": "sha512-Q7OBervGf5jL/SRcYSwbkySoY37De+S6WHzT2isLPSXTdneLFUofvFgwzWypYI1U5WeFZozXBsrfIxyi+tbppw==",
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@gnosis.pm/gno-token/-/gno-token-1.0.1.tgz",
+          "integrity": "sha1-zsRRGW7JR1ShdyvUe4ezkGyYgMM=",
           "requires": {
-            "@gnosis.pm/util-contracts": "1.1.1"
+            "@gnosis.pm/util-contracts": "^1.0.1"
           }
+        },
+        "@gnosis.pm/util-contracts": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/@gnosis.pm/util-contracts/-/util-contracts-1.0.2.tgz",
+          "integrity": "sha512-RHv65Hxxixx2zwoQdAC345RV9MySTsLIaLFblSD2QPcncppBJSeewfqBY0ZZWxARaJqvCuFa4A2ZF9xOBwftqg=="
         }
       }
     },
+    "@gnosis.pm/gno-token": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@gnosis.pm/gno-token/-/gno-token-1.0.1.tgz",
+      "integrity": "sha1-zsRRGW7JR1ShdyvUe4ezkGyYgMM=",
+      "requires": {
+        "@gnosis.pm/util-contracts": "^1.0.1"
+      }
+    },
+    "@gnosis.pm/owl-token": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@gnosis.pm/owl-token/-/owl-token-1.1.2.tgz",
+      "integrity": "sha512-OP2JeVxZFNQxiwG9sPTHgXnocjFgVpmpou6p1kxcz1kFiKCzF28MrabiDNrVRo1PIZ1lfUiVe+Ser0n5r0ckwg==",
+      "requires": {
+        "@gnosis.pm/gno-token": "^1.0.1",
+        "@gnosis.pm/util-contracts": "^1.0.1"
+      }
+    },
     "@gnosis.pm/util-contracts": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@gnosis.pm/util-contracts/-/util-contracts-1.1.1.tgz",
-      "integrity": "sha512-ckEpppnw6KiGKMHwUJpLsdpsCKUAvYmPaLsdX0aDe4hwVaDJzvtq5ot9YUrzmhOMbUUW3wDSMMJ+fHTpntRL7A=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@gnosis.pm/util-contracts/-/util-contracts-1.0.2.tgz",
+      "integrity": "sha512-RHv65Hxxixx2zwoQdAC345RV9MySTsLIaLFblSD2QPcncppBJSeewfqBY0ZZWxARaJqvCuFa4A2ZF9xOBwftqg=="
     },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
@@ -4254,8 +4259,7 @@
     "bindings": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
-      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw==",
-      "dev": true
+      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
     },
     "bip39": {
       "version": "2.5.0",
@@ -4274,7 +4278,6 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
       "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
-      "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -6635,7 +6638,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
       "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
-      "dev": true,
       "requires": {
         "browserify-aes": "^1.0.6",
         "create-hash": "^1.1.2",
@@ -7689,14 +7691,12 @@
       "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
       "dev": true,
       "requires": {
-        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#00ba8463a7f7a67fcad737ff9c2ebd95643427f7",
         "ethereumjs-util": "^5.1.1"
       },
       "dependencies": {
         "ethereumjs-abi": {
-          "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#00ba8463a7f7a67fcad737ff9c2ebd95643427f7",
-          "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
-          "dev": true,
+          "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+          "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
           "requires": {
             "bn.js": "^4.10.0",
             "ethereumjs-util": "^5.0.0"
@@ -7905,7 +7905,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
       "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
-      "dev": true,
       "requires": {
         "bn.js": "^4.11.0",
         "create-hash": "^1.1.2",
@@ -8018,7 +8017,6 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
       "integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
-      "dev": true,
       "requires": {
         "is-hex-prefixed": "1.0.0",
         "strip-hex-prefix": "1.0.0"
@@ -9074,7 +9072,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -9111,7 +9110,8 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
@@ -9120,7 +9120,8 @@
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -9223,7 +9224,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -9233,6 +9235,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -9252,11 +9255,13 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -9273,6 +9278,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -9345,7 +9351,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -9355,6 +9362,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -9430,7 +9438,8 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -9460,6 +9469,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -9477,6 +9487,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -9515,11 +9526,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -13052,7 +13065,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
       "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
-      "dev": true,
       "requires": {
         "bindings": "^1.2.1",
         "inherits": "^2.0.3",
@@ -13193,8 +13205,7 @@
         "pem-jwk": "^1.5.1",
         "protons": "^1.0.1",
         "rsa-pem-to-jwk": "^1.1.3",
-        "tweetnacl": "^1.0.0",
-        "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+        "tweetnacl": "^1.0.0"
       },
       "dependencies": {
         "js-sha3": {
@@ -13216,6 +13227,10 @@
             "murmurhash3js": "^3.0.1",
             "nodeify": "^1.0.1"
           }
+        },
+        "webcrypto-shim": {
+          "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
+          "from": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
         }
       }
     },
@@ -15983,8 +15998,13 @@
             "pem-jwk": "^1.5.1",
             "protons": "^1.0.1",
             "rsa-pem-to-jwk": "^1.1.3",
-            "tweetnacl": "^1.0.0",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+            "tweetnacl": "^1.0.0"
+          },
+          "dependencies": {
+            "webcrypto-shim": {
+              "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
+              "from": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+            }
           }
         },
         "multiaddr": {
@@ -16028,6 +16048,10 @@
             "lodash": "^4.17.5",
             "multihashes": "~0.4.13"
           }
+        },
+        "webcrypto-shim": {
+          "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
+          "from": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
         }
       }
     },
@@ -20006,7 +20030,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.1.0.tgz",
       "integrity": "sha512-93U7IKH5j7nmXFVg19MeNBGzQW5uXW1pmCuKY8veeKIhYTE32C2d0mOegfiIAfXcHOKJjjPlJisn8iHDF5AezA==",
-      "dev": true,
       "requires": {
         "safe-buffer": "^5.1.1"
       }
@@ -20292,7 +20315,6 @@
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.5.0.tgz",
       "integrity": "sha512-e5QIJl8W7Y4tT6LHffVcZAxJjvpgE5Owawv6/XCYPQljE9aP2NFFddQ8OYMKhdLshNu88FfL3qCN3/xYkXGRsA==",
-      "dev": true,
       "requires": {
         "bindings": "^1.2.1",
         "bip66": "^1.1.3",
@@ -22771,7 +22793,6 @@
           "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.6.tgz",
           "integrity": "sha1-PpcwauAk+yThCj11yIQwJWIhUSA=",
           "requires": {
-            "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
             "crypto-js": "^3.1.4",
             "utf8": "^2.1.1",
             "xhr2": "*",
@@ -22780,7 +22801,7 @@
           "dependencies": {
             "bignumber.js": {
               "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-              "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
+              "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
             }
           }
         }
@@ -23684,7 +23705,6 @@
       "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.7.tgz",
       "integrity": "sha512-VU6/DSUX93d1fCzBz7WP/SGCQizO1rKZi4Px9j/3yRyfssHyFcZamMw2/sj4E8TlfMXONvZLoforR8B4bRoyTQ==",
       "requires": {
-        "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
         "crypto-js": "^3.1.4",
         "utf8": "^2.1.1",
         "xhr2-cookies": "^1.1.0",
@@ -23693,7 +23713,7 @@
       "dependencies": {
         "bignumber.js": {
           "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
+          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
         },
         "crypto-js": {
           "version": "3.1.8",
@@ -23777,11 +23797,6 @@
           }
         }
       }
-    },
-    "webcrypto-shim": {
-      "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
-      "from": "github:dignifiedquire/webcrypto-shim#master",
-      "dev": true
     },
     "webidl-conversions": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -77,9 +77,9 @@
     ]
   },
   "dependencies": {
-    "@gnosis.pm/dx-contracts": "^1.0.8",
-    "@gnosis.pm/gno-token": "^1.1.2",
-    "@gnosis.pm/util-contracts": "^1.0.2",
+    "@gnosis.pm/dx-contracts": "^1.0.9",
+    "@gnosis.pm/gno-token": "1.0.1",
+    "@gnosis.pm/util-contracts": "1.0.2",
     "bignumber.js": "5.0.0",
     "connected-react-router": "4.4.1",
     "cross-env": "^5.1.6",


### PR DESCRIPTION
Locked in versions compatible with latest `dx-contracts` `DutchExchange` version

```
    "@gnosis.pm/dx-contracts": "^1.0.9",
    "@gnosis.pm/gno-token": "1.0.1",
    "@gnosis.pm/util-contracts": "1.0.2",
...
```